### PR TITLE
Add rainbow styling

### DIFF
--- a/chalk.js
+++ b/chalk.js
@@ -60,3 +60,20 @@ chalk.supportsColor = require('has-color');
 if (chalk.enabled === undefined) {
 	chalk.enabled = chalk.supportsColor;
 }
+
+// rainbow style
+var rainbowColors = [
+	chalk.red,
+	chalk.yellow,
+	chalk.green,
+	chalk.blue,
+	chalk.magenta
+];
+chalk.rainbow = function(str) {
+	var arStr = str.split(''),
+		out = '';
+	for (var i in arStr) {
+		out += rainbowColors[i % rainbowColors.length](arStr[i]);
+	}
+	return out;
+};

--- a/test.js
+++ b/test.js
@@ -29,6 +29,10 @@ describe('chalk', function () {
 	it('should alias gray to grey', function () {
 		assert.equal(chalk.grey('foo'), '\x1b[90mfoo\x1b[39m');
 	});
+
+	it('should style a string in rainbow colors', function () {
+		assert.equal(chalk.rainbow('rygbmr g\tm\ny'), '\x1b[31mr\x1b[39m\x1b[33my\x1b[39m\x1b[32mg\x1b[39m\x1b[34mb\x1b[39m\x1b[35mm\x1b[39m\x1b[31mr\x1b[39m\x1b[33m \x1b[39m\x1b[32mg\x1b[39m\x1b[34m\t\x1b[39m\x1b[35mm\x1b[39m\x1b[31m\n\x1b[39m\x1b[33my\x1b[39m');
+	});
 });
 
 describe('chalk.enabled', function () {


### PR DESCRIPTION
![reading-rainbow](https://f.cloud.github.com/assets/1027776/1063261/674fc10c-129d-11e3-81a0-4a5a96d55462.gif)

Color.js supports a feature that outputs a rainbow colored string.  My Yeoman generator used it and I am working on converting it over to chalk.  I can change the display, especially since rainbow text is kind of like this:
![puking-rainbow](https://f.cloud.github.com/assets/1027776/1063265/951e1eee-129d-11e3-8934-bb8ceea70211.gif)

But, if you would like to support it, here is the feature...
