### PR TITLE
Variable arguments and falsy values

### DIFF
--- a/chalk.js
+++ b/chalk.js
@@ -27,7 +27,9 @@ function init() {
 	Object.keys(styles).forEach(function (name) {
 		ret[name] = {
 			get: function () {
-				var obj = defineProps(function self(str) {
+				var obj = defineProps(function self() {
+					var str = [].slice.call(arguments).join(' ');
+
 					if (!chalk.enabled) {
 						return str;
 					}

--- a/readme.md
+++ b/readme.md
@@ -34,13 +34,16 @@ var chalk = require('chalk');
 console.log(chalk.blue('Hello world!'));
 
 // combine styled and normal strings
-console.log(chalk.blue('Hello') + 'World' + chalk.red('!'));
+console.log(chalk.blue('Hello'), 'World' + chalk.red('!'));
 
 // compose multiple styles using the chainable API
 console.log(chalk.blue.bgRed.bold('Hello world!'));
 
 // nest styles
-chalk.red('Hello' + chalk.underline.bgBlue('world') + '!');
+chalk.red('Hello', chalk.underline.bgBlue('world') + '!');
+
+// pass in multiple arguments
+console.log(chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz')) 
 ```
 
 You can easily define your own themes.
@@ -58,6 +61,7 @@ console.log(error('Error!'));
 
 Chain [styles](#styles) and call the last one as a method with a string argument.
 
+Multiple arguments are also supported. Chalk will add a space between each one.
 
 ### chalk.enabled
 

--- a/test.js
+++ b/test.js
@@ -29,6 +29,14 @@ describe('chalk', function () {
 	it('should alias gray to grey', function () {
 		assert.equal(chalk.grey('foo'), '\x1b[90mfoo\x1b[39m');
 	});
+
+	it('should support variable number of arguments', function () {
+		assert.equal(chalk.red('foo', 'bar'), '\x1b[31mfoo bar\x1b[39m');
+	});
+
+	it('should support falsy values', function () {
+		assert.equal(chalk.red(0), '\x1b[31m0\x1b[39m');
+	});
 });
 
 describe('chalk.enabled', function () {


### PR DESCRIPTION
Adds ability to handle passing in variable arguments (ex. `chalk.green("it's", "over", 9000)`). This also fixes issue #6. The readme has been updated to include passing in variable arguments in the examples.
