### PR TITLE
slicing arguments without new array instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function init() {
 		ret[name] = {
 			get: function () {
 				var obj = defineProps(function self() {
-					var str = [].slice.call(arguments).join(' ');
+					var str = Array.prototype.slice.call(arguments).join(' ');
 
 					if (!chalk.enabled) {
 						return str;


### PR DESCRIPTION
`[].slice.call(arguments).join(' ')` is called on every access thus an new array is created every time.
using only the prototype method from the `Array` constructor is sufficient and possibly benefits performance.
