### PR TITLE
Adds support for nested chalk expressions.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ console.log(  chalk.blue.bgRed.bold('Hello world!')  );
 // nest styles
 console.log(  chalk.red('Hello', chalk.underline.bgBlue('world') + '!')  );
 
+// nest styles of the same type even (colour, underline, background)
+console.log( chalk.green('Hello, I'm a green line ' + chalk.blue('with a blue substring') + ' that becomes green again!') );
+
 // pass in multiple arguments
 console.log(  chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz')  );
 ```

--- a/test.js
+++ b/test.js
@@ -21,6 +21,13 @@ describe('chalk', function () {
 		);
 	});
 
+	it('should support nesting styles of the same type (color, underline, bg)', function () {
+		assert.equal(
+			chalk.red('a' + chalk.blue('b' + chalk.green('c') + 'b') + 'c'),
+			'\u001b[31ma\u001b[34mb\u001b[32mc\u001b[34mb\u001b[31mc\u001b[39m'
+		);
+	});
+
 	it('should reset all styles with `.reset()`', function () {
 		assert.equal(chalk.reset(chalk.red.bgGreen.underline('foo') + 'foo'), '\u001b[0m\u001b[4m\u001b[42m\u001b[31mfoo\u001b[39m\u001b[49m\u001b[24mfoo\u001b[0m');
 	});


### PR DESCRIPTION
green(a + blue(b) + c) will now look the same as green(a) +
blue(b) + green(c), as expected. In the previous implementation the
output would have been green(a) + blue(b) + c, because the reset code of
the second expression would close all expressions around it as well.

Now this reset code is replaced by a start code of the outer lying
expression, both stopping the inner and re-starting the outer.

For example:

![screen shot 2014-06-21 at 06 21 53](https://cloud.githubusercontent.com/assets/3891755/3347835/d235d92a-f8fc-11e3-9151-938c3d9a4c32.png)

Where previously everything after the inner green text would have been white.
