### PR TITLE
Replaces Array.prototype.reduce with an explicit loop for performance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,17 @@ function applyStyle() {
 		return str;
 	}
 
-	return applyStyle._styles.reduce(function (str, name) {
-		var code = ansiStyles[name];
+	var nestedStyles = applyStyle._styles;
+
+	for (var i = 0; i < nestedStyles.length; i++) {
+		var code = ansiStyles[nestedStyles[i]];
 		// Replace any instances already present with a re-opening code
 		// otherwise only the part of the string until said closing code
 		// will be colored, and the rest will simply be 'plain'.
-		return code.open + str.replace(code.closeRe, code.open) + code.close;
-	}, str) ;
+		str = code.open + str.replace(code.closeRe, code.open) + code.close;
+	}
+
+	return str;
 }
 
 function init() {


### PR DESCRIPTION
Noticed the call to [].reduce was possibly the hottest code path, and tried replacing it with the supposedly faster `fast.js` implementation - see [repo](https://github.com/codemix/fast.js)

Amazingly, benchmarking shows this is little over 20% faster.

I'm pretty sure the edge cases not handled by `fast.js` will not be a problem in this case. Sparse arrays, for instance, are an impossibility in our current usage. 
