### PR TITLE
Reverses application of styles, now left-to-right

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ function applyStyle() {
 	/*jshint validthis: true*/
 	var nestedStyles = this._styles;
 
-	for (var i = 0; i < nestedStyles.length; i++) {
+	var i = nestedStyles.length;
+	while (i--) {
 		var code = ansiStyles[nestedStyles[i]];
 		// Replace any instances already present with a re-opening code
 		// otherwise only the part of the string until said closing code

--- a/test.js
+++ b/test.js
@@ -10,14 +10,14 @@ describe('chalk', function () {
 	});
 
 	it('should support applying multiple styles at once', function () {
-		assert.equal(chalk.red.bgGreen.underline('foo'), '\u001b[4m\u001b[42m\u001b[31mfoo\u001b[39m\u001b[49m\u001b[24m');
-		assert.equal(chalk.underline.red.bgGreen('foo'), '\u001b[42m\u001b[31m\u001b[4mfoo\u001b[24m\u001b[39m\u001b[49m');
+		assert.equal(chalk.red.bgGreen.underline('foo'), '\u001b[31m\u001b[42m\u001b[4mfoo\u001b[24m\u001b[49m\u001b[39m');
+		assert.equal(chalk.underline.red.bgGreen('foo'), '\u001b[4m\u001b[31m\u001b[42mfoo\u001b[49m\u001b[39m\u001b[24m');
 	});
 
 	it('should support nesting styles', function () {
 		assert.equal(
 			chalk.red('foo' + chalk.underline.bgBlue('bar') + '!'),
-			'\u001b[31mfoo\u001b[44m\u001b[4mbar\u001b[24m\u001b[49m!\u001b[39m'
+			'\u001b[31mfoo\u001b[4m\u001b[44mbar\u001b[49m\u001b[24m!\u001b[39m'
 		);
 	});
 
@@ -29,7 +29,7 @@ describe('chalk', function () {
 	});
 
 	it('should reset all styles with `.reset()`', function () {
-		assert.equal(chalk.reset(chalk.red.bgGreen.underline('foo') + 'foo'), '\u001b[0m\u001b[4m\u001b[42m\u001b[31mfoo\u001b[39m\u001b[49m\u001b[24mfoo\u001b[0m');
+		assert.equal(chalk.reset(chalk.red.bgGreen.underline('foo') + 'foo'), '\u001b[0m\u001b[31m\u001b[42m\u001b[4mfoo\u001b[24m\u001b[49m\u001b[39mfoo\u001b[0m');
 	});
 
 	it('should be able to cache multiple styles', function() {


### PR DESCRIPTION
The styles' application order used to to be right-to-left e.g.:

``` javascript
console.log(chalk.red.reset.blue('something'))
// red
```

Where now it has been reversed. E.g.:

``` javascript
console.log(chalk.red.reset.blue('something'))
// blue
```

It seems to me that this is the more intuitive application order.

Closes #41
