### PR TITLE
supports-color@3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "escape-string-regexp": "^1.0.2",
     "has-ansi": "^2.0.0",
     "strip-ansi": "^3.0.0",
-    "supports-color": "^2.0.0"
+    "supports-color": "^3.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Currently chalk breaks when run in Electron's renderer. Upgrading to `supports-color@3.1.1` fixes the issue.

Thanks! :)