### PR TITLE
Remove has-ansi and strip-ansi dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 'use strict';
 var escapeStringRegexp = require('escape-string-regexp');
 var ansiStyles = require('ansi-styles');
-var stripAnsi = require('strip-ansi');
-var hasAnsi = require('has-ansi');
 var supportsColor = require('supports-color');
 var defineProps = Object.defineProperties;
 var isSimpleWindowsTerm = process.platform === 'win32' && !/^xterm/i.test(process.env.TERM);
@@ -111,6 +109,4 @@ defineProps(Chalk.prototype, init());
 
 module.exports = new Chalk();
 module.exports.styles = ansiStyles;
-module.exports.hasColor = hasAnsi;
-module.exports.stripColor = stripAnsi;
 module.exports.supportsColor = supportsColor;

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
   "dependencies": {
     "ansi-styles": "^2.1.0",
     "escape-string-regexp": "^1.0.2",
-    "has-ansi": "^2.0.0",
-    "strip-ansi": "^3.0.0",
     "supports-color": "^2.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -140,27 +140,6 @@ console.log(chalk.styles.red);
 console.log(chalk.styles.red.open + 'Hello' + chalk.styles.red.close);
 ```
 
-### chalk.hasColor(string)
-
-Check whether a string [has color](https://github.com/chalk/has-ansi).
-
-### chalk.stripColor(string)
-
-[Strip color](https://github.com/chalk/strip-ansi) from a string.
-
-Can be useful in combination with `.supportsColor` to strip color on externally styled text when it's not supported.
-
-Example:
-
-```js
-const chalk = require('chalk');
-let styledString = getText();
-
-if (!chalk.supportsColor) {
-	styledString = chalk.stripColor(styledString);
-}
-```
-
 
 ## Styles
 

--- a/test.js
+++ b/test.js
@@ -142,16 +142,3 @@ describe('chalk.styles', function () {
 		assert.equal(chalk.styles.red.open, '\u001b[31m');
 	});
 });
-
-describe('chalk.hasColor()', function () {
-	it('should detect whether a string has color', function () {
-		assert(chalk.hasColor(chalk.green('foo')));
-		assert(!chalk.hasColor(chalk.stripColor(chalk.green('foo'))));
-	});
-});
-
-describe('chalk.stripColor()', function () {
-	it('should strip color from string', function () {
-		assert.equal(chalk.stripColor(chalk.underline.red.bgGreen('foo')), 'foo');
-	});
-});


### PR DESCRIPTION
This PR fixes #70, removes `has-ansi` and `strip-ansi` dependencies as well as corresponding methods.