### PR TITLE
Closing before and reopening the style after a line break

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ function applyStyle() {
 		// otherwise only the part of the string until said closing code
 		// will be colored, and the rest will simply be 'plain'.
 		str = code.open + str.replace(code.closeRe, code.open) + code.close;
+
+		// Close the coloring before a line break and reopening after next line
+		// To fix a bleed issue on macs
+		// see https://github.com/chalk/chalk/pull/92
+		str = str.replace(/\n/gm, code.close + '\n' + code.open);
 	}
 
 	// Reset the original 'dim' if we changed it to work around the Windows dimmed gray issue.

--- a/test.js
+++ b/test.js
@@ -61,6 +61,10 @@ describe('chalk', function () {
 	it('don\'t output escape codes if the input is empty', function () {
 		assert.equal(chalk.red(), '');
 	});
+
+	it('line breaks should open and close colors', function () {
+		assert.equal(chalk.grey('hello\nworld'), '\u001b[90mhello\u001b[39m\n\u001b[90mworld\u001b[39m');
+	});
 });
 
 describe('chalk on windows', function () {


### PR DESCRIPTION
In mac terminals line breaks inside a styled text - particularly at the end of a string - can break the color rendering. Take this example:

```JavaScript
chalk.bgGreen('hello\n')
```

This text embedded in another longer paragraph would look like this:

![screenshot 2015-12-16 00 19 02](https://cloud.githubusercontent.com/assets/914122/11814591/f93c051e-a38a-11e5-9857-8ee06986ac78.png)

After this PR it would be rendered as below.

![screenshot 2015-12-16 00 17 59](https://cloud.githubusercontent.com/assets/914122/11814556/cb37c6c6-a38a-11e5-9e5b-38fd1cfbec11.png)

Caveats: I havn't tested this on other platforms and the code is not exactly super-high-performing but it should do the job.

_Note: Screenshots taken with iTerm2 on latest Mac OS_