### PR TITLE
Add log statement to chalk examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,11 +71,11 @@ log(chalk.green(
 ));
 
 // ES2015 template literal
-const systemStats = `
+log(`
 CPU: ${chalk.red('90%')}
 RAM: ${chalk.green('40%')}
 DISK: ${chalk.yellow('70%')}
-`;
+`);
 ```
 
 Easily define your own themes.

--- a/readme.md
+++ b/readme.md
@@ -47,29 +47,28 @@ console.log(chalk.blue('Hello world!'));
 
 Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
 
-Here without `console.log` for purity.
-
 ```js
 const chalk = require('chalk');
+const log = console.log;
 
 // combine styled and normal strings
-chalk.blue('Hello') + 'World' + chalk.red('!');
+log(chalk.blue('Hello') + 'World' + chalk.red('!'));
 
 // compose multiple styles using the chainable API
-chalk.blue.bgRed.bold('Hello world!');
+log(chalk.blue.bgRed.bold('Hello world!'));
 
 // pass in multiple arguments
-chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz');
+log(chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz'));
 
 // nest styles
-chalk.red('Hello', chalk.underline.bgBlue('world') + '!');
+log(chalk.red('Hello', chalk.underline.bgBlue('world') + '!'));
 
 // nest styles of the same type even (color, underline, background)
-chalk.green(
+log(chalk.green(
 	'I am a green line ' +
 	chalk.blue.underline.bold('with a blue substring') +
 	' that becomes green again!'
-);
+));
 
 // ES2015 template literal
 const systemStats = `


### PR DESCRIPTION
Added what are essentially `console.log()` calls to the chalk examples.

Closes #128.