### PR TITLE
Add RGB (256/Truecolor) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 'stable'
   - '6'
   - '4'
 after_success: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - 'stable'
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'
 after_success: npm run coveralls

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ var supportsColor = require('supports-color');
 var defineProps = Object.defineProperties;
 var isSimpleWindowsTerm = process.platform === 'win32' && !/^xterm/i.test(process.env.TERM);
 
+// supportsColor.level -> ansiStyles.color[name] mapping
 var levelMapping = ['ansi', 'ansi', 'ansi256', 'ansi16m'];
+// color-convert models to exclude from the Chalk API due to conflicts and such.
 var skipModels = ['gray'];
 
 function Chalk(options) {

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var defineProps = Object.defineProperties;
 var isSimpleWindowsTerm = process.platform === 'win32' && !/^xterm/i.test(process.env.TERM);
 
 function Chalk(options) {
-	// detect mode if not set manually
-	this.enabled = !options || options.enabled === undefined ? supportsColor : options.enabled;
+	// detect level if not set manually
+	this.level = !options || options.level === undefined ? supportsColor.level : options.level;
 }
 
 // use bright blue on Windows as the normal blue color is illegible
@@ -37,7 +37,7 @@ function build(_styles) {
 	};
 
 	builder._styles = _styles;
-	builder.enabled = this.enabled;
+	builder.level = this.level;
 	// __proto__ is used because we must return a function, but there is
 	// no way to create a function with a different prototype.
 	/* eslint-disable no-proto */
@@ -59,7 +59,7 @@ function applyStyle() {
 		}
 	}
 
-	if (!this.enabled || !str) {
+	if (!this.level || !str) {
 		return str;
 	}
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function build(_styles, key) {
 	var self = this;
 
 	builder._styles = _styles;
-  
+
 	Object.defineProperty(builder, 'level', {
 		enumerable: true,
 		get: function () {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "text"
   ],
   "dependencies": {
-    "ansi-styles": "^2.1.0",
+    "ansi-styles": "^3.0.0",
     "escape-string-regexp": "^1.0.2",
-    "supports-color": "^3.1.2"
+    "supports-color": "^3.2.3"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,8 @@ For a complete list of color models, see [`color-convert`'s list of conversions]
 As of this writing, these are the supported color models that are exposed in Chalk:
 
 - `rgb`
+- `hex`
+- `keyword` (CSS keywords)
 - `hsl`
 - `hsv`
 - `hwb`
@@ -219,12 +221,10 @@ As of this writing, these are the supported color models that are exposed in Cha
 - `xyz`
 - `lab`
 - `lch`
-- `hex`
-- `keyword`
 - `ansi16`
 - `ansi256`
 - `hcg`
-- `apple`
+- `apple` (see [qix-/color-convert#30](https://github.com/Qix-/color-convert/issues/30))
 
 ## Windows
 

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ const ctx = new chalk.constructor({level: 0});
 
 Levels are as follows:
 
-0. All color disabled
+0. All colors disabled
 1. Basic color support (16 colors)
 2. 256 color support
 3. RGB/Truecolor support (16 million colors)

--- a/readme.md
+++ b/readme.md
@@ -198,12 +198,11 @@ For supported methods (listed below), the color will be 'fit' to the color level
 
 Some examples:
 
-For a complete list of color models, see [`color-convert`'s list of conversions](https://github.com/Qix-/color-convert/blob/master/conversions.js). Background versions of these models are prefixed with `bg` and the first level of the module capitalized (e.g. `keyword` for foreground colors and `bgKeyword` for background colors).
-
 - `chalk.hex('#DEADED').underline('Hello, world!')`
 - `chalk.keyword('orange')('Some orange text')`
 - `chalk.rgb(15, 100, 204).inverse('Hello!')`
 
+Background versions of these models are prefixed with `bg` and the first level of the module capitalized (e.g. `keyword` for foreground colors and `bgKeyword` for background colors).
 
 - `chalk.bgHex('#DEADED').underline('Hello, world!')`
 - `chalk.bgKeyword('orange')('Some orange text')`
@@ -225,6 +224,8 @@ As of this writing, these are the supported color models that are exposed in Cha
 - `ansi256`
 - `hcg`
 - `apple` (see [qix-/color-convert#30](https://github.com/Qix-/color-convert/issues/30))
+
+For a complete list of color models, see [`color-convert`'s list of conversions](https://github.com/Qix-/color-convert/blob/master/conversions.js).
 
 ## Windows
 

--- a/readme.md
+++ b/readme.md
@@ -76,14 +76,23 @@ CPU: ${chalk.red('90%')}
 RAM: ${chalk.green('40%')}
 DISK: ${chalk.yellow('70%')}
 `);
+
+// Use RGB colors in terminal emulators that support it.
+log(chalk.keyword('orange')('Yay for orange colored text!'));
+log(chalk.rgb(123, 45, 67).underline('Underlined reddish color'));
+log(chalk.hex('#DEADED').bold('Bold gray!'));
 ```
 
 Easily define your own themes.
 
 ```js
 const chalk = require('chalk');
+
 const error = chalk.bold.red;
+const warning = chalk.keyword('orange');
+
 console.log(error('Error!'));
+console.log(warning('Warning!'));
 ```
 
 Take advantage of console.log [string substitution](http://nodejs.org/docs/latest/api/console.html#console_console_log_data).
@@ -105,15 +114,22 @@ Chain [styles](#styles) and call the last one as a method with a string argument
 
 Multiple arguments will be separated by space.
 
-### chalk.enabled
+### chalk.level
 
-Color support is automatically detected, but you can override it by setting the `enabled` property. You should however only do this in your own code as it applies globally to all chalk consumers.
+Color support is automatically detected, but you can override it by setting the `level` property. You should however only do this in your own code as it applies globally to all chalk consumers.
 
 If you need to change this in a reusable module create a new instance:
 
 ```js
-const ctx = new chalk.constructor({enabled: false});
+const ctx = new chalk.constructor({level: 0});
 ```
+
+Levels are as follows:
+
+0. All color disabled
+1. Basic color support (16 colors)
+2. 256 color support
+3. RGB/Truecolor support (16 million colors)
 
 ### chalk.supportsColor
 
@@ -174,10 +190,30 @@ console.log(chalk.styles.red.open + 'Hello' + chalk.styles.red.close);
 - `bgWhite`
 
 
-## 256-colors
+## 256/16 million (Truecolor) color support
 
-Chalk does not support anything other than the base eight colors, which guarantees it will work on all terminals and systems. Some terminals, specifically `xterm` compliant ones, will support the full range of 8-bit colors. For this the lower level [ansi-256-colors](https://github.com/jbnicolai/ansi-256-colors) package can be used.
+Chalk supports 256 colors and, when manually specified, [Truecolor (16 million colors)](https://gist.github.com/XVilka/8346728) on all supported terminal emulators.
 
+For the methods that support it (listed below), the color will be 'fit' to the color level supported (i.e. RGB colors will be downsampled to 16 colors if only basic support is enabled).
+
+For a complete list of color models, see [`color-convert`'s list of conversions](https://github.com/Qix-/color-convert/blob/master/conversions.js). Background versions of these models are prefixed with `bg` and the first level of the module capitalized (e.g. `keyword` for foreground colors and `bgKeyword` for background colors).
+
+As of this writing, these are the supported color models that are exposed in Chalk:
+
+- `rgb`
+- `hsl`
+- `hsv`
+- `hwb`
+- `cmyk`
+- `xyz`
+- `lab`
+- `lch`
+- `hex`
+- `keyword`
+- `ansi16`
+- `ansi256`
+- `hcg`
+- `apple`
 
 ## Windows
 
@@ -194,6 +230,7 @@ If you're on Windows, do yourself a favor and use [`cmder`](http://cmder.net/) i
 - [ansi-regex](https://github.com/chalk/ansi-regex) - Regular expression for matching ANSI escape codes
 - [wrap-ansi](https://github.com/chalk/wrap-ansi) - Wordwrap a string with ANSI escape codes
 - [slice-ansi](https://github.com/chalk/slice-ansi) - Slice a string with ANSI escape codes
+- [color-convert](https://github.com/qix-/color-convert) - Converts colors between different models
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ console.log(chalk.styles.red.open + 'Hello' + chalk.styles.red.close);
 
 Chalk supports 256 colors and, when manually specified, [Truecolor (16 million colors)](https://gist.github.com/XVilka/8346728) on all supported terminal emulators.
 
-For supported methods (listed below), the color will be 'fit' to the color level supported (i.e. RGB colors will be downsampled to 16 colors if only basic support is enabled).
+Colors are downsampled from 16 million RGB values to an ANSI color format that is supported by the terminal emulator (or by specifying {level: n} as a chalk option). For example, Chalk configured to run at level 1 (basic color support) will downsample an RGB value of #FF0000 (red) to 31 (ANSI escape for red).
 
 Some examples:
 

--- a/readme.md
+++ b/readme.md
@@ -210,10 +210,10 @@ Background versions of these models are prefixed with `bg` and the first level o
 
 As of this writing, these are the supported color models that are exposed in Chalk:
 
-- `rgb`
-- `hex`
-- `keyword` (CSS keywords)
-- `hsl`
+- `rgb` - e.g. `chalk.rgb(255, 136, 0).bold('Orange!')`
+- `hex` - e.g. `chalk.hex('#ff8800').bold('Orange!')`
+- `keyword` (CSS keywords) - e.g. `chalk.keyword('orange').bold('Orange!')`
+- `hsl` - e.g. `chalk.hsl(32, 100, 50).bold('Orange!')`
 - `hsv`
 - `hwb`
 - `cmyk`

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ console.log(chalk.styles.red.open + 'Hello' + chalk.styles.red.close);
 
 Chalk supports 256 colors and, when manually specified, [Truecolor (16 million colors)](https://gist.github.com/XVilka/8346728) on all supported terminal emulators.
 
-For the methods that support it (listed below), the color will be 'fit' to the color level supported (i.e. RGB colors will be downsampled to 16 colors if only basic support is enabled).
+For supported methods (listed below), the color will be 'fit' to the color level supported (i.e. RGB colors will be downsampled to 16 colors if only basic support is enabled).
 
 Some examples:
 

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,18 @@ Chalk supports 256 colors and, when manually specified, [Truecolor (16 million c
 
 For the methods that support it (listed below), the color will be 'fit' to the color level supported (i.e. RGB colors will be downsampled to 16 colors if only basic support is enabled).
 
+Some examples:
+
 For a complete list of color models, see [`color-convert`'s list of conversions](https://github.com/Qix-/color-convert/blob/master/conversions.js). Background versions of these models are prefixed with `bg` and the first level of the module capitalized (e.g. `keyword` for foreground colors and `bgKeyword` for background colors).
+
+- `chalk.hex('#DEADED').underline('Hello, world!')`
+- `chalk.keyword('orange')('Some orange text')`
+- `chalk.rgb(15, 100, 204).inverse('Hello!')`
+
+
+- `chalk.bgHex('#DEADED').underline('Hello, world!')`
+- `chalk.bgKeyword('orange')('Some orange text')`
+- `chalk.bgRgb(15, 100, 204).inverse('Hello!')`
 
 As of this writing, these are the supported color models that are exposed in Chalk:
 

--- a/test.js
+++ b/test.js
@@ -161,25 +161,28 @@ describe('chalk.level', function () {
 	});
 
 	it('should enable/disable colors based on overall chalk enabled property, not individual instances', function () {
-		chalk.enabled = true;
+		var oldLevel = chalk.level;
+		chalk.level = 1;
 		var red = chalk.red;
-		assert.equal(red.enabled, true);
-		chalk.enabled = false;
-		assert.equal(red.enabled, chalk.enabled);
-		chalk.enabled = true;
+		assert.equal(red.level, 1);
+		chalk.level = 0;
+		assert.equal(red.level, chalk.level);
+		chalk.level = oldLevel;
 	});
 
 	it('should propagate enable/disable changes from child colors', function () {
-		chalk.enabled = true;
+		var oldLevel = chalk.level;
+		chalk.level = 1;
 		var red = chalk.red;
-		assert.equal(red.enabled, true);
-		assert.equal(chalk.enabled, true);
-		red.enabled = false;
-		assert.equal(red.enabled, false);
-		assert.equal(chalk.enabled, false);
-		chalk.enabled = true;
-		assert.equal(red.enabled, true);
-		assert.equal(chalk.enabled, true);
+		assert.equal(red.level, 1);
+		assert.equal(chalk.level, 1);
+		red.level = 0;
+		assert.equal(red.level, 0);
+		assert.equal(chalk.level, 0);
+		chalk.level = 1;
+		assert.equal(red.level, 1);
+		assert.equal(chalk.level, 1);
+		chalk.level = oldLevel;
 	});
 });
 

--- a/test.js
+++ b/test.js
@@ -72,6 +72,26 @@ describe('chalk', function () {
 	it('line breaks should open and close colors', function () {
 		assert.equal(chalk.grey('hello\nworld'), '\u001b[90mhello\u001b[39m\n\u001b[90mworld\u001b[39m');
 	});
+
+	it('should properly convert RGB to 16 colors on basic color terminals', function () {
+		assert.equal(new chalk.constructor({level: 1}).hex('#FF0000')('hello'), '\u001b[91mhello\u001b[39m');
+		assert.equal(new chalk.constructor({level: 1}).bgHex('#FF0000')('hello'), '\u001b[101mhello\u001b[49m');
+	});
+
+	it('should properly convert RGB to 256 colors on basic color terminals', function () {
+		assert.equal(new chalk.constructor({level: 2}).hex('#FF0000')('hello'), '\u001b[38;5;196mhello\u001b[39m');
+		assert.equal(new chalk.constructor({level: 2}).bgHex('#FF0000')('hello'), '\u001b[48;5;196mhello\u001b[49m');
+	});
+
+	it('should properly convert RGB to 256 colors on basic color terminals', function () {
+		assert.equal(new chalk.constructor({level: 3}).hex('#FF0000')('hello'), '\u001b[38;2;255;0;0mhello\u001b[39m');
+		assert.equal(new chalk.constructor({level: 3}).bgHex('#FF0000')('hello'), '\u001b[48;2;255;0;0mhello\u001b[49m');
+	});
+
+	it('should not emit RGB codes if level is 0', function () {
+		assert.equal(new chalk.constructor({level: 0}).hex('#FF0000')('hello'), 'hello');
+		assert.equal(new chalk.constructor({level: 0}).bgHex('#FF0000')('hello'), 'hello');
+	});
 });
 
 describe('chalk on windows', function () {

--- a/test.js
+++ b/test.js
@@ -132,17 +132,18 @@ describe('chalk on windows', function () {
 	});
 });
 
-describe('chalk.enabled', function () {
+describe('chalk.level', function () {
 	it('should not output colors when manually disabled', function () {
-		chalk.enabled = false;
+		var oldLevel = chalk.level;
+		chalk.level = 0;
 		assert.equal(chalk.red('foo'), 'foo');
-		chalk.enabled = true;
+		chalk.level = oldLevel;
 	});
 });
 
 describe('chalk.constructor', function () {
 	it('should create a isolated context where colors can be disabled', function () {
-		var ctx = new chalk.constructor({enabled: false});
+		var ctx = new chalk.constructor({level: 0});
 		assert.equal(ctx.red('foo'), 'foo');
 		assert.equal(chalk.red('foo'), '\u001b[31mfoo\u001b[39m');
 	});


### PR DESCRIPTION
Finally closes #73.

References #20, #35, #37, #57, #87, #126. We know some of you have been waiting for this one for a very long time.

This PR is blocked by a few remaining issues over at [`supports-color`](https://github.com/chalk/supports-color). @sindresorhus has promised me he will take a look at those and make some executive decisions within the coming week. After they are resolved, its version will be bumped in this PR and, pending approval from the community, this will be merged and released.

This is an additive release - however, please see the breaking changes section below for a reason why it's a major release.

This adds two new suites of chalk-able modes:

1. Foreground RGB colors using [`color-convert`](https://github.com/qix-/color-convert) models as names (e.g. `chalk.rgb(123, 45, 67)` or `chalk.keyword('orange')`)
2. Background RGB colors, similar to the foreground colors above but with a camel-cased `bg` prefix, (e.g. `chalk.bgRgb(123, 45, 67)` or `chalk.bgKeyword('orange')`)

All RGB color functions in turn return your usual chalk builder. Some examples:

- `chalk.hex('#DEADED').underline('Hello, world!')`
- `chalk.keyword('orange')('Some orange text')`
- `chalk.rgb(15, 100, 204).inverse('Hello!')`

This is per [@silverwind's suggestion](https://github.com/chalk/chalk/issues/73#issuecomment-124826052) in #73, which we agreed is the most intuitive way to approach this API.

---

**This module now requires Node.js 4 or above**. This is why it is a major release bump.

The only potentially API-related breaking changes is if you use Chalk's `.enabled` property, you'll need to replace it with `.level`, which is now an integer (where `0` indicates not enabled and anything >= 1 indicates enabled, and further, one of several levels of color granularity).

As well, if you're passing an option to chalk to forcefully set whether or not it's enabled, you'll need to change:

- `{enabled: false}` -> `{level: 0}`, or
- `{enabled: true}` -> `{level: 1}` (or whatever level you'd like - level 1 is equivalent to Chalk's current level of support).

The levels, as described in [`supports-color`](https://github.com/chalk/supports-color), are:

0. Disabled
1. 16 colors (basic color)
2. 256 colors (most widely supported mode in terminals that support more than 16 colors)
3. 16 million colors ("truecolor") - be sure to check [if your emulator supports Truecolor codes](https://gist.github.com/XVilka/8346728)

---

Please don't hesitate to give me feedback on the new API.

Thanks for everyone's continued patience - let this be a celebration of some of the first OSS contributions I made here on Github, and let it serve as a relic of some of the great connections I've made through it. 🦄 

---

cc @sindresorhus @jbnicolai @dthree @silverwind @stevemao @arthurvr @mikeerickson @rektide @mattbasta, as well as @XVilka (Thank you for your research on support! It has [proven invaluable](http://stackoverflow.com/a/26665998/510036) in many ways.)

Thanks everyone!

![Look at all the colors!!!!](https://media.giphy.com/media/z0zTHzcwM4VYQ/giphy.gif)