### PR TITLE
Check parent builder object for enabled status

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,20 @@ function build(_styles) {
 		return applyStyle.apply(builder, arguments);
 	};
 
+	var self = this;
+
 	builder._styles = _styles;
-	builder.enabled = this.enabled;
+
+	Object.defineProperty(builder, 'enabled', {
+		enumerable: true,
+		get: function () {
+			return self.enabled;
+		},
+		set: function (v) {
+			self.enabled = v;
+		}
+	});
+
 	// __proto__ is used because we must return a function, but there is
 	// no way to create a function with a different prototype.
 	/* eslint-disable no-proto */

--- a/test.js
+++ b/test.js
@@ -138,6 +138,28 @@ describe('chalk.enabled', function () {
 		assert.equal(chalk.red('foo'), 'foo');
 		chalk.enabled = true;
 	});
+
+	it('should enable/disable colors based on overall chalk enabled property, not individual instances', function () {
+		chalk.enabled = true;
+		var red = chalk.red;
+		assert.equal(red.enabled, true);
+		chalk.enabled = false;
+		assert.equal(red.enabled, chalk.enabled);
+		chalk.enabled = true;
+	});
+
+	it('should propagate enable/disable changes from child colors', function () {
+		chalk.enabled = true;
+		var red = chalk.red;
+		assert.equal(red.enabled, true);
+		assert.equal(chalk.enabled, true);
+		red.enabled = false;
+		assert.equal(red.enabled, false);
+		assert.equal(chalk.enabled, false);
+		chalk.enabled = true;
+		assert.equal(red.enabled, true);
+		assert.equal(chalk.enabled, true);
+	});
 });
 
 describe('chalk.constructor', function () {


### PR DESCRIPTION
This fixes an issue where child builders do not propagate their enabled statuses to the parents and vice versa.

For example, prior to this PR:

```javascript
var chalk = require('chalk');

console.log(chalk.enabled); // true

var red = chalk.red;
console.log(red.enabled); // true

chalk.enabled = false;

console.log(red.enabled); // true  (should be false!)
```

This PR fixes that; getting/setting `.enabled` on any builder (anything stemming from the root `chalk` object) now reflects the `.enabled` value on chalk as a whole.