### PR TITLE
Re-implement `chalk.enabled`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ const skipModels = new Set(['gray']);
 
 function Chalk(options) {
 	// Detect level if not set manually
-	this.level = !options || options.level === undefined ? supportsColor.level : options.level;
+	this.level = Number(!options || options.level === undefined ? supportsColor.level : options.level);
+	this.enabled = options && 'enabled' in options ? options.enabled : this.level > 0;
 }
 
 // Use bright blue on Windows as the normal blue color is illegible
@@ -89,6 +90,7 @@ function build(_styles, key) {
 	builder._styles = _styles;
 
 	const self = this;
+
 	Object.defineProperty(builder, 'level', {
 		enumerable: true,
 		get() {
@@ -96,6 +98,16 @@ function build(_styles, key) {
 		},
 		set(level) {
 			self.level = level;
+		}
+	});
+
+	Object.defineProperty(builder, 'enabled', {
+		enumerable: true,
+		get() {
+			return self.enabled;
+		},
+		set(enabled) {
+			self.enabled = enabled;
 		}
 	});
 
@@ -122,7 +134,7 @@ function applyStyle() {
 		}
 	}
 
-	if (!this.level || !str) {
+	if (!this.enabled || this.level <= 0 || !str) {
 		return str;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -115,11 +115,23 @@ Chain [styles](#styles) and call the last one as a method with a string argument
 
 Multiple arguments will be separated by space.
 
+### chalk.enabled
+
+Color support is automatically detected, as is the level (see `chalk.level`). However, if you'd like to simply enable/disable chalk, you can do so via the `.enabled` property.
+
+Chalk is enabled by default unless expicitly disabled via the constructor.
+
+If you need to change this in a reusable module, create a new instance:
+
+```js
+const ctx = new chalk.constructor({enabled: false});
+```
+
 ### chalk.level
 
 Color support is automatically detected, but you can override it by setting the `level` property. You should however only do this in your own code as it applies globally to all Chalk consumers.
 
-If you need to change this in a reusable module create a new instance:
+If you need to change this in a reusable module, create a new instance:
 
 ```js
 const ctx = new chalk.constructor({level: 0});

--- a/readme.md
+++ b/readme.md
@@ -117,9 +117,9 @@ Multiple arguments will be separated by space.
 
 ### chalk.enabled
 
-Color support is automatically detected, as is the level (see `chalk.level`). However, if you'd like to simply enable/disable chalk, you can do so via the `.enabled` property.
+Color support is automatically detected, as is the level (see `chalk.level`). However, if you'd like to simply enable/disable Chalk, you can do so via the `.enabled` property.
 
-Chalk is enabled by default unless expicitly disabled via the constructor.
+Chalk is enabled by default unless expicitly disabled via the constructor or `chalk.level` is `0`.
 
 If you need to change this in a reusable module, create a new instance:
 

--- a/test.js
+++ b/test.js
@@ -194,10 +194,51 @@ describe('chalk.level', () => {
 	});
 });
 
+describe('chalk.enabled', () => {
+	it('should not output colors when manually disabled', () => {
+		chalk.enabled = false;
+		assert.equal(chalk.red('foo'), 'foo');
+		chalk.enabled = true;
+	});
+
+	it('should enable/disable colors based on overall chalk enabled property, not individual instances', () => {
+		chalk.enabled = false;
+		const red = chalk.red;
+		assert.equal(red.enabled, false);
+		chalk.enabled = true;
+		assert.equal(red.enabled, true);
+		chalk.enabled = true;
+	});
+
+	it('should propagate enable/disable changes from child colors', () => {
+		chalk.enabled = false;
+		const red = chalk.red;
+		assert.equal(red.enabled, false);
+		assert.equal(chalk.enabled, false);
+		red.enabled = true;
+		assert.equal(red.enabled, true);
+		assert.equal(chalk.enabled, true);
+		chalk.enabled = false;
+		assert.equal(red.enabled, false);
+		assert.equal(chalk.enabled, false);
+		chalk.enabled = true;
+	});
+});
+
 describe('chalk.constructor', () => {
-	it('should create a isolated context where colors can be disabled', () => {
-		const ctx = new chalk.constructor({level: 0});
+	it('should create an isolated context where colors can be disabled (by level)', () => {
+		const ctx = new chalk.constructor({level: 0, enabled: true});
 		assert.equal(ctx.red('foo'), 'foo');
 		assert.equal(chalk.red('foo'), '\u001B[31mfoo\u001B[39m');
+		ctx.level = 2;
+		assert.equal(ctx.red('foo'), '\u001B[31mfoo\u001B[39m');
+	});
+
+	it('should create an isolated context where colors can be disabled (by enabled flag)', () => {
+		const ctx = new chalk.constructor({enabled: false});
+		assert.equal(ctx.red('foo'), 'foo');
+		assert.equal(chalk.red('foo'), '\u001B[31mfoo\u001B[39m');
+		ctx.enabled = true;
+		assert.equal(ctx.red('foo'), '\u001B[31mfoo\u001B[39m');
 	});
 });


### PR DESCRIPTION
Adds the `.enabled` property back in. Fixes #159.