### PR TITLE
Add tagged template literal

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"templates.js"
 	],
 	"keywords": [
 		"color",

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,13 @@ RAM: ${chalk.green('40%')}
 DISK: ${chalk.yellow('70%')}
 `);
 
+// ES2015/ES2016 tagged template literal
+log(chalk`
+CPU: {red ${cpu.totalPercent}%}
+RAM: {green ${ram.used / ram.total * 100}%}
+DISK: {rgb(255,131,0) ${disk.used / disk.total * 100}%}
+`);
+
 // Use RGB colors in terminal emulators that support it.
 log(chalk.keyword('orange')('Yay for orange colored text!'));
 log(chalk.rgb(123, 45, 67).underline('Underlined reddish color'));
@@ -205,6 +212,37 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 - `bgCyanBright`
 - `bgWhiteBright`
 
+## Template Literal Tagging
+
+`chalk` by itself can be used as a [tagged template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).
+
+This means you can use template strings in ES2015/ES2016 literals (<code>chalk&grave;hello&grave;</code>) to template large or multi-line strings.
+
+```javascript
+const chalk = require('chalk');
+
+const miles = 18;
+const calculateFeet = miles => miles * 5280;
+
+console.log(chalk`
+  There are {bold 5280 feet} in a mile.
+  In {bold ${miles} miles}, there are {green.bold ${calculateFeet(miles)} feet}.
+`);
+```
+
+Blocks are delimited by an opening curly brace (`{`), a style, some content, and a closing curly brace (`}`).
+
+Template styles are chained exactly like normal Chalk styles. The following two statements are equivalent.
+
+```javascript
+console.log(chalk.bold.rgb(10, 100, 200)('Hello!'));
+console.log(chalk`{bold.rgb(10,100,200) Hello!}`);
+```
+
+Note that function styles (`rgb()`, `hsl()`, `keyword()`, etc.) may not contain spaces between parameters.
+
+All interpolated values (<code>chalk&grave;${foo}&grave;</code>) are converted to strings via the `.toString()` method.
+All curly braces (`{` and `}`) in interpolated value strings are escaped.
 
 ## 256 and Truecolor color support
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ RAM: ${chalk.green('40%')}
 DISK: ${chalk.yellow('70%')}
 `);
 
-// ES2015/ES2016 tagged template literal
+// ES2015 tagged template literal
 log(chalk`
 CPU: {red ${cpu.totalPercent}%}
 RAM: {green ${ram.used / ram.total * 100}%}
@@ -212,13 +212,12 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 - `bgCyanBright`
 - `bgWhiteBright`
 
-## Template Literal Tagging
 
-`chalk` by itself can be used as a [tagged template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).
+## Tagged template literal
 
-This means you can use template strings in ES2015/ES2016 literals (<code>chalk&grave;hello&grave;</code>) to template large or multi-line strings.
+Chalk can be used as a [tagged template literal](http://exploringjs.com/es6/ch_template-literals.html#_tagged-template-literals).
 
-```javascript
+```js
 const chalk = require('chalk');
 
 const miles = 18;
@@ -232,17 +231,17 @@ console.log(chalk`
 
 Blocks are delimited by an opening curly brace (`{`), a style, some content, and a closing curly brace (`}`).
 
-Template styles are chained exactly like normal Chalk styles. The following two statements are equivalent.
+Template styles are chained exactly like normal Chalk styles. The following two statements are equivalent:
 
-```javascript
+```js
 console.log(chalk.bold.rgb(10, 100, 200)('Hello!'));
 console.log(chalk`{bold.rgb(10,100,200) Hello!}`);
 ```
 
 Note that function styles (`rgb()`, `hsl()`, `keyword()`, etc.) may not contain spaces between parameters.
 
-All interpolated values (<code>chalk&grave;${foo}&grave;</code>) are converted to strings via the `.toString()` method.
-All curly braces (`{` and `}`) in interpolated value strings are escaped.
+All interpolated values (`` chalk`${foo}` ``) are converted to strings via the `.toString()` method. All curly braces (`{` and `}`) in interpolated value strings are escaped.
+
 
 ## 256 and Truecolor color support
 

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,175 @@
+'use strict';
+
+function data(parent) {
+	return {
+		styles: [],
+		parent,
+		contents: []
+	};
+}
+
+const zeroBound = n => n < 0 ? 0 : n;
+const lastIndex = a => zeroBound(a.length - 1);
+
+const last = a => a[lastIndex(a)];
+
+const takeWhileReverse = (array, predicate, start) => {
+	const out = [];
+
+	for (let i = start; i >= 0 && i <= start; i--) {
+		if (predicate(array[i])) {
+			out.unshift(array[i]);
+		} else {
+			break;
+		}
+	}
+
+	return out;
+};
+
+/**
+ * Checks if the character at position i in string is a normal character a.k.a a non control character.
+ * */
+const isNormalCharacter = (string, i) => {
+	const char = string[i];
+	const backslash = '\\';
+
+	if (!(char === backslash || char === '{' || char === '}')) {
+		return true;
+	}
+
+	const n = i === 0 ? 0 : takeWhileReverse(string, x => x === '\\', zeroBound(i - 1)).length;
+
+	return n % 2 === 1;
+};
+
+const collectStyles = data => data ? collectStyles(data.parent).concat(data.styles) : ['reset'];
+
+/**
+ * Computes the style for a given data based on it's style and the style of it's parent. Also accounts for !style styles
+ * which remove a style from the list if present.
+ * */
+const sumStyles = data => {
+	const negateRegex = /^~.+/;
+	let out = [];
+
+	for (const style of collectStyles(data)) {
+		if (negateRegex.test(style)) {
+			const exclude = style.slice(1);
+			out = out.filter(x => x !== exclude);
+		} else {
+			out.push(style);
+		}
+	}
+
+	return out;
+};
+
+/**
+ * Takes a string and parses it into a tree of data objects which inherit styles from their parent.
+ * */
+function parse(string) {
+	const root = data(null);
+	let pushingStyle = false;
+
+	let current = root;
+
+	for (let i = 0; i < string.length; i++) {
+		const char = string[i];
+
+		const addNormalCharacter = () => {
+			const lastChunk = last(current.contents);
+
+			if (typeof lastChunk === 'string') {
+				current.contents[lastIndex(current.contents)] = lastChunk + char;
+			} else {
+				current.contents.push(char);
+			}
+		};
+
+		if (pushingStyle) {
+			if (' \t'.indexOf(char) > -1) {
+				pushingStyle = false;
+			} else if (char === '\n') {
+				pushingStyle = false;
+				addNormalCharacter();
+			} else if (char === '.') {
+				current.styles.push('');
+			} else {
+				current.styles[lastIndex(current.styles)] = (last(current.styles) || '') + char;
+			}
+		} else if (isNormalCharacter(string, i)) {
+			addNormalCharacter();
+		} else if (char === '{') {
+			pushingStyle = true;
+			const nCurrent = data(current);
+			current.contents.push(nCurrent);
+			current = nCurrent;
+		} else if (char === '}') {
+			current = current.parent;
+		}
+	}
+
+	if (current !== root) {
+		throw new Error('literal template has an unclosed block');
+	}
+
+	return root;
+}
+
+/**
+ * Takes a tree of data objects and flattens it to a list of data objects with the inherited and negations styles
+ * accounted for.
+ * */
+function flatten(data) {
+	let flat = [];
+
+	for (const content of data.contents) {
+		if (typeof content === 'string') {
+			flat.push({
+				styles: sumStyles(data),
+				content
+			});
+		} else {
+			flat = flat.concat(flatten(content));
+		}
+	}
+
+	return flat;
+}
+
+function assertStyle(chalk, style) {
+	if (!chalk[style]) {
+		throw new Error(`invalid Chalk style: ${style}`);
+	}
+}
+
+/**
+ * Checks if a given style is valid and parses style functions.
+ * */
+function parseStyle(chalk, style) {
+	const fnMatch = style.match(/^\s*(\w+)\s*\(\s*([^)]*)\s*\)\s*/);
+	if (!fnMatch) {
+		assertStyle(chalk, style);
+		return chalk[style];
+	}
+
+	const name = fnMatch[1].trim();
+	const args = fnMatch[2].split(/,/g).map(s => s.trim());
+
+	assertStyle(chalk, name);
+
+	return chalk[name].apply(chalk, args);
+}
+
+/**
+ * Performs the actual styling of the string, essentially lifted from cli.js.
+ * */
+function style(chalk, flat) {
+	return flat.map(data => {
+		const fn = data.styles.reduce(parseStyle, chalk);
+		return fn(data.content.replace(/\n$/, ''));
+	}).join('');
+}
+
+module.exports = (chalk, string) => style(chalk, flatten(parse(string)));

--- a/test.js
+++ b/test.js
@@ -19,6 +19,10 @@ console.log('host TERM=', process.env.TERM || '[none]');
 console.log('host platform=', process.platform || '[unknown]');
 
 describe('chalk', () => {
+	it('should not add any styling when called as the base function', () => {
+		assert.equal(chalk('foo'), 'foo');
+	});
+
 	it('should style string', () => {
 		assert.equal(chalk.underline('foo'), '\u001B[4mfoo\u001B[24m');
 		assert.equal(chalk.red('foo'), '\u001B[31mfoo\u001B[39m');
@@ -240,5 +244,96 @@ describe('chalk.constructor', () => {
 		assert.equal(chalk.red('foo'), '\u001B[31mfoo\u001B[39m');
 		ctx.enabled = true;
 		assert.equal(ctx.red('foo'), '\u001B[31mfoo\u001B[39m');
+	});
+});
+
+describe('chalk tag literal', () => {
+	it('should return an empty string for an empty literal', () => {
+		const ctx = chalk.constructor();
+		assert.equal(ctx``, '');
+	});
+
+	it('should return a regular string for a literal with no templates', () => {
+		const ctx = chalk.constructor({level: 0});
+		assert.equal(ctx`hello`, 'hello');
+	});
+
+	it('should correctly perform template parsing', () => {
+		const ctx = chalk.constructor({level: 0});
+		assert.equal(ctx`{bold Hello, {cyan World!} This is a} test. {green Woo!}`,
+			ctx.bold('Hello,', ctx.cyan('World!'), 'This is a') + ' test. ' + ctx.green('Woo!'));
+	});
+
+	it('should correctly perform template substitutions', () => {
+		const ctx = chalk.constructor({level: 0});
+		const name = 'Sindre';
+		const exclamation = 'Neat';
+		assert.equal(ctx`{bold Hello, {cyan.inverse ${name}!} This is a} test. {green ${exclamation}!}`,
+			ctx.bold('Hello,', ctx.cyan.inverse(name + '!'), 'This is a') + ' test. ' + ctx.green(exclamation + '!'));
+	});
+
+	it('should correctly parse and evaluate color-convert functions', () => {
+		const ctx = chalk.constructor({level: 3});
+		assert.equal(ctx`{bold.rgb(144,10,178).inverse Hello, {~inverse there!}}`,
+			'\u001b[0m\u001b[1m\u001b[38;2;144;10;178m\u001b[7mHello, ' +
+			'\u001b[27m\u001b[39m\u001b[22m\u001b[0m\u001b[0m\u001b[1m' +
+			'\u001b[38;2;144;10;178mthere!\u001b[39m\u001b[22m\u001b[0m');
+
+		assert.equal(ctx`{bold.bgRgb(144,10,178).inverse Hello, {~inverse there!}}`,
+			'\u001b[0m\u001b[1m\u001b[48;2;144;10;178m\u001b[7mHello, ' +
+			'\u001b[27m\u001b[49m\u001b[22m\u001b[0m\u001b[0m\u001b[1m' +
+			'\u001b[48;2;144;10;178mthere!\u001b[49m\u001b[22m\u001b[0m');
+	});
+
+	it('should properly handle escapes', () => {
+		const ctx = chalk.constructor({level: 3});
+		assert.equal(ctx`{bold hello \{in brackets\}}`,
+			'\u001b[0m\u001b[1mhello {in brackets}\u001b[22m\u001b[0m');
+	});
+
+	it('should throw if there is an unclosed block', () => {
+		const ctx = chalk.constructor({level: 3});
+		try {
+			console.log(ctx`{bold this shouldn't appear ever\}`);
+			assert.fail();
+		} catch (err) {
+			assert.equal(err.message, 'literal template has an unclosed block');
+		}
+	});
+
+	it('should throw if there is an invalid style', () => {
+		const ctx = chalk.constructor({level: 3});
+		try {
+			console.log(ctx`{abadstylethatdoesntexist this shouldn't appear ever}`);
+			assert.fail();
+		} catch (err) {
+			assert.equal(err.message, 'invalid Chalk style: abadstylethatdoesntexist');
+		}
+	});
+
+	it('should properly style multiline color blocks', () => {
+		const ctx = chalk.constructor({level: 3});
+		assert.equal(
+			ctx`{bold
+				Hello! This is a
+				${'multiline'} block!
+				:)
+			} {underline
+				I hope you enjoy
+			}`,
+			'\u001b[0m\u001b[1m\u001b[22m\u001b[0m\n' +
+			'\u001b[0m\u001b[1m\t\t\t\tHello! This is a\u001b[22m\u001b[0m\n' +
+			'\u001b[0m\u001b[1m\t\t\t\tmultiline block!\u001b[22m\u001b[0m\n' +
+			'\u001b[0m\u001b[1m\t\t\t\t:)\u001b[22m\u001b[0m\n' +
+			'\u001b[0m\u001b[1m\t\t\t\u001b[22m\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[4m\u001b[24m\u001b[0m\n' +
+			'\u001b[0m\u001b[4m\t\t\t\tI hope you enjoy\u001b[24m\u001b[0m\n' +
+			'\u001b[0m\u001b[4m\t\t\t\u001b[24m\u001b[0m'
+		);
+	});
+
+	it('should escape interpolated values', () => {
+		const ctx = chalk.constructor({level: 0});
+		assert.equal(ctx`Hello {bold hi}`, 'Hello hi');
+		assert.equal(ctx`Hello ${'{bold hi}'}`, 'Hello {bold hi}');
 	});
 });

--- a/test.js
+++ b/test.js
@@ -247,7 +247,7 @@ describe('chalk.constructor', () => {
 	});
 });
 
-describe('chalk tag literal', () => {
+describe('tagged template literal', () => {
 	it('should return an empty string for an empty literal', () => {
 		const ctx = chalk.constructor();
 		assert.equal(ctx``, '');
@@ -275,20 +275,20 @@ describe('chalk tag literal', () => {
 	it('should correctly parse and evaluate color-convert functions', () => {
 		const ctx = chalk.constructor({level: 3});
 		assert.equal(ctx`{bold.rgb(144,10,178).inverse Hello, {~inverse there!}}`,
-			'\u001b[0m\u001b[1m\u001b[38;2;144;10;178m\u001b[7mHello, ' +
-			'\u001b[27m\u001b[39m\u001b[22m\u001b[0m\u001b[0m\u001b[1m' +
-			'\u001b[38;2;144;10;178mthere!\u001b[39m\u001b[22m\u001b[0m');
+			'\u001B[0m\u001B[1m\u001B[38;2;144;10;178m\u001B[7mHello, ' +
+			'\u001B[27m\u001B[39m\u001B[22m\u001B[0m\u001B[0m\u001B[1m' +
+			'\u001B[38;2;144;10;178mthere!\u001B[39m\u001B[22m\u001B[0m');
 
 		assert.equal(ctx`{bold.bgRgb(144,10,178).inverse Hello, {~inverse there!}}`,
-			'\u001b[0m\u001b[1m\u001b[48;2;144;10;178m\u001b[7mHello, ' +
-			'\u001b[27m\u001b[49m\u001b[22m\u001b[0m\u001b[0m\u001b[1m' +
-			'\u001b[48;2;144;10;178mthere!\u001b[49m\u001b[22m\u001b[0m');
+			'\u001B[0m\u001B[1m\u001B[48;2;144;10;178m\u001B[7mHello, ' +
+			'\u001B[27m\u001B[49m\u001B[22m\u001B[0m\u001B[0m\u001B[1m' +
+			'\u001B[48;2;144;10;178mthere!\u001B[49m\u001B[22m\u001B[0m');
 	});
 
 	it('should properly handle escapes', () => {
 		const ctx = chalk.constructor({level: 3});
 		assert.equal(ctx`{bold hello \{in brackets\}}`,
-			'\u001b[0m\u001b[1mhello {in brackets}\u001b[22m\u001b[0m');
+			'\u001B[0m\u001B[1mhello {in brackets}\u001B[22m\u001B[0m');
 	});
 
 	it('should throw if there is an unclosed block', () => {
@@ -321,13 +321,13 @@ describe('chalk tag literal', () => {
 			} {underline
 				I hope you enjoy
 			}`,
-			'\u001b[0m\u001b[1m\u001b[22m\u001b[0m\n' +
-			'\u001b[0m\u001b[1m\t\t\t\tHello! This is a\u001b[22m\u001b[0m\n' +
-			'\u001b[0m\u001b[1m\t\t\t\tmultiline block!\u001b[22m\u001b[0m\n' +
-			'\u001b[0m\u001b[1m\t\t\t\t:)\u001b[22m\u001b[0m\n' +
-			'\u001b[0m\u001b[1m\t\t\t\u001b[22m\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[4m\u001b[24m\u001b[0m\n' +
-			'\u001b[0m\u001b[4m\t\t\t\tI hope you enjoy\u001b[24m\u001b[0m\n' +
-			'\u001b[0m\u001b[4m\t\t\t\u001b[24m\u001b[0m'
+			'\u001B[0m\u001B[1m\u001B[22m\u001B[0m\n' +
+			'\u001B[0m\u001B[1m\t\t\t\tHello! This is a\u001B[22m\u001B[0m\n' +
+			'\u001B[0m\u001B[1m\t\t\t\tmultiline block!\u001B[22m\u001B[0m\n' +
+			'\u001B[0m\u001B[1m\t\t\t\t:)\u001B[22m\u001B[0m\n' +
+			'\u001B[0m\u001B[1m\t\t\t\u001B[22m\u001B[0m\u001B[0m \u001B[0m\u001B[0m\u001B[4m\u001B[24m\u001B[0m\n' +
+			'\u001B[0m\u001B[4m\t\t\t\tI hope you enjoy\u001B[24m\u001B[0m\n' +
+			'\u001B[0m\u001B[4m\t\t\t\u001B[24m\u001B[0m'
 		);
 	});
 


### PR DESCRIPTION
Got kind of bored tonight and added chalk tagged literals.


Example:

```javascript
const chalk = require('chalk');

console.log(chalk`
CPU: {red.bold.inverse 90%}
RAM: {green.bold 40%}
DISK: {rgb(255,131,0).bold 70%}
`);
```

Gives you:

<img width="242" alt="screen shot 2017-06-28 at 10 18 39 pm" src="https://user-images.githubusercontent.com/885648/27672429-c6f7a5b6-5c4f-11e7-8dbf-81d19f151e1b.png">

Should be 100% backwards compatible&ast;. Only caveat is that it doesn't work with `new chalk.constructor(options)`. Just have to drop the `new` to get the tag-able version. This, however, means that all existing code that calls `new chalk.constructor` is unaffected.

We might want to update `chalk-cli`, too, as this is a modified implementation to allow for the new 256/truecolor methods.

&ast; Backwards compatible API-wise (down to the `new chalk.constructor(opts)` bit). However unless we want to do `arguments` concatenation acrobatics instead of splats in `index.js`, Node 6 is required :P Up to you, @sindresorhus. I have no strong opinions either way.