### PR TITLE
Demonstrate crash when using Truecolor methods and color is unsupported

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -1,0 +1,4 @@
+'use strict';
+const chalk = require('.');
+
+console.log(chalk.hex('#ff6159')('test'));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	},
 	"devDependencies": {
 		"coveralls": "^2.11.2",
+		"execa": "^0.7.0",
 		"import-fresh": "^2.0.0",
 		"matcha": "^0.7.0",
 		"mocha": "*",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 const assert = require('assert');
 const importFresh = require('import-fresh');
 const resolveFrom = require('resolve-from');
+const execa = require('execa');
 
 // Spoof supports-color
 require.cache[resolveFrom(__dirname, 'supports-color')] = {
@@ -201,6 +202,13 @@ describe('chalk.level', () => {
 		assert.equal(red.level, 1);
 		assert.equal(chalk.level, 1);
 		chalk.level = oldLevel;
+	});
+
+	it('should disable colors if they are not supported', () => {
+		return execa('node', ['fixture'])
+			.then(result => {
+				assert.equal(result.stdout, 'test');
+			});
 	});
 });
 


### PR DESCRIPTION
Failing test for https://github.com/chalk/chalk/issues/175.