### PR TITLE
Return empty `string` when there are no arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function applyStyle() {
 	// Support varags, but simply cast to string in case there's only one arg
 	const args = arguments;
 	const argsLen = args.length;
-	let str = argsLen !== 0 && String(arguments[0]);
+	let str = argsLen === 0 ? '' : String(arguments[0]);
 
 	if (argsLen > 1) {
 		// Don't slice `arguments`, it prevents V8 optimizations

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function applyStyle() {
 	// Support varags, but simply cast to string in case there's only one arg
 	const args = arguments;
 	const argsLen = args.length;
-	let str = argsLen !== 0 && String(arguments[0]);
+	let str = String(arguments[0]);
 
 	if (argsLen === 0) {
 		return '';

--- a/index.js
+++ b/index.js
@@ -152,7 +152,11 @@ function applyStyle() {
 	// Support varags, but simply cast to string in case there's only one arg
 	const args = arguments;
 	const argsLen = args.length;
-	let str = argsLen === 0 ? '' : String(arguments[0]);
+	let str = argsLen !== 0 && String(arguments[0]);
+
+	if (argsLen === 0) {
+		return '';
+	}
 
 	if (argsLen > 1) {
 		// Don't slice `arguments`, it prevents V8 optimizations


### PR DESCRIPTION
Fixes https://github.com/chalk/chalk/pull/182#issuecomment-317263716.