### PR TITLE
Fix template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,8 +207,8 @@ function chalkTag(chalk, strings) {
 	const parts = [strings.raw[0]];
 
 	for (let i = 1; i < strings.length; i++) {
-		parts.push(args[i - 1].toString().replace(/[{}\\]/g, '\\$&'));
-		parts.push(strings.raw[i]);
+		parts.push(String(args[i - 1]).replace(/[{}\\]/g, '\\$&'));
+		parts.push(String(strings.raw[i]));
 	}
 
 	return template(chalk, parts.join(''));

--- a/index.js
+++ b/index.js
@@ -197,12 +197,13 @@ function applyStyle() {
 }
 
 function chalkTag(chalk, strings) {
-	const args = [].slice.call(arguments, 2);
-
 	if (!Array.isArray(strings)) {
-		return strings.toString();
+		// If chalk() was called by itself or with a string,
+		// return the string itself as a string.
+		return [].slice.call(arguments, 1).join(' ');
 	}
 
+	const args = [].slice.call(arguments, 2);
 	const parts = [strings.raw[0]];
 
 	for (let i = 1; i < strings.length; i++) {

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function chalkTag(chalk, strings) {
 	const parts = [strings.raw[0]];
 
 	for (let i = 1; i < strings.length; i++) {
-		parts.push(args[i - 1].toString().replace(/[{}]/g, '\\$&'));
+		parts.push(args[i - 1].toString().replace(/[{}\\]/g, '\\$&'));
 		parts.push(strings.raw[i]);
 	}
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function applyOptions(obj, options) {
 	options = options || {};
 
 	// Detect level if not set manually
-	obj.level = options.level === undefined ? supportsColor.level : options.level;
+	const scLevel = supportsColor ? supportsColor.level : 0;
+	obj.level = options.level === undefined ? scLevel : options.level;
 	obj.enabled = 'enabled' in options ? options.enabled : obj.level > 0;
 }
 

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -12,6 +12,10 @@ test('don\'t add any styling when called as the base function', t => {
 	t.is(m('foo'), 'foo');
 });
 
+test('support multiple arguments in base function', t => {
+	t.is(m('hello', 'there'), 'hello there');
+});
+
 test('style string', t => {
 	t.is(m.underline('foo'), '\u001B[4mfoo\u001B[24m');
 	t.is(m.red('foo'), '\u001B[31mfoo\u001B[39m');

--- a/test/level.js
+++ b/test/level.js
@@ -39,6 +39,6 @@ test('propagate enable/disable changes from child colors', t => {
 	m.level = oldLevel;
 });
 
-test.failing('disable colors if they are not supported', async t => {
+test('disable colors if they are not supported', async t => {
 	t.is(await execa.stdout('node', [path.join(__dirname, '_fixture')]), 'test');
 });

--- a/test/template-literal.js
+++ b/test/template-literal.js
@@ -93,3 +93,26 @@ test('escape interpolated values', t => {
 	t.is(ctx`Hello {bold hi}`, 'Hello hi');
 	t.is(ctx`Hello ${'{bold hi}'}`, 'Hello {bold hi}');
 });
+
+test('allow custom colors (themes) on custom contexts', t => {
+	const ctx = m.constructor({level: 3});
+	ctx.rose = ctx.hex('#F6D9D9');
+	t.is(ctx`Hello, {rose Rose}.`, '\u001b[0mHello, \u001b[38;2;246;217;217mRose\u001b[38m.\u001b[0m');
+});
+
+test('correctly parse newline literals (bug #184)', t => {
+	const ctx = m.constructor({level: 0});
+	t.is(ctx`Hello
+{red there}`, 'Hello\nthere');
+});
+
+test('correctly parse newline escapes (bug #177)', t => {
+	const ctx = m.constructor({level: 0});
+	t.is(ctx`Hello\nthere!`, `Hello\nthere!`);
+});
+
+test('correctly parse escape in parameters (bug #177 comment 318622809)', t => {
+	const ctx = m.constructor({level: 0});
+	const str = '\\';
+	t.is(ctx`{blue ${str}}`, '\\');
+});

--- a/test/template-literal.js
+++ b/test/template-literal.js
@@ -161,3 +161,9 @@ test('should not parse upper-case escapes', t => {
 	const ctx = m.constructor({level: 0});
 	t.is(ctx`\N\n\T\t\X07\x07\U000A\u000A\U000a\u000a`, 'N\nT\tX07\x07U000A\u000AU000a\u000A');
 });
+
+test('should properly handle undefined template interpolated values', t => {
+	const ctx = m.constructor({level: 0});
+	t.is(ctx`hello ${undefined}`, 'hello undefined');
+	t.is(ctx`hello ${null}`, 'hello null');
+});


### PR DESCRIPTION
So the old templating code wasn't really build for how we are utilizing template literals today. A lot of the bugs we faced were the result of unforeseen/unspec'd requirements that were imposed upon the existing code.

I took a somewhat different approach - a manual parser is all fine and good, but it's tricky to maintain, especially when lots of things pop up and once or when the scope/intent of the code changes drastically (as can be seen by the bug tracker :taco:).

It's served us well thus far but I felt it was time to give it a little bit of a ✨ makeover ✨.

As a result, it fixes a bunch of bugs and introduces the ability to add custom theme values to your chalk instance and use them in templates (#186).

```javascript
const chalk = require('chalk');

const theme = chalk.constructor();
theme.rose = theme.hex('#F69D9D');

console.log(theme`Here is some {rose rosy text!}`);
```

I feel like I'll need to justify using regular expressions here instead of manual parsing:

1. They're being (ab)used mainly as tokenizers
2. The longest one is just a series of smol patterns or'd together
3. It greatly simplifies the codebase and keeps maintenance costs low (you can drop them into regex101.com and make changes as necessary)

By using templates, you're already [incurring quite a bit of overhead](https://stackoverflow.com/a/29083467/510036) in tight loops, so the template literal parsing code is going to be of negligible overhead.

Don't be fooled by the diff of `templates.js` - it's a complete rewrite. Don't waste your time trying to parse the diff 😅  Not sure why Git isn't better at detecting rewrites.

Closes #186
Fixes #184 
Fixes #187 
Fixes #176 
Fixes #175 
Fixes #177 
Fixes #194

cc @vadimdemedes

---

Note to merger: It's probably best _not_ to squash this particular PR. I took a bit of time to rebase it prior to PRing in order to have a nice and clean fast-forward/rebase. cc @sindresorhus