### PR TITLE
Paraquire - paranoidal require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
-const escapeStringRegexp = require('escape-string-regexp');
-const ansiStyles = require('ansi-styles');
-const supportsColor = require('supports-color');
+
+const paraquire = require('paraquire')(module);
+
+const escapeStringRegexp = paraquire('escape-string-regexp');
+const ansiStyles = paraquire('ansi-styles');
+const supportsColor = paraquire('supports-color', {builtin: ['os'], process: ['argv', 'env', 'platform', 'stdout', 'versions']});
 
 const template = require('./templates.js');
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	"dependencies": {
 		"ansi-styles": "^3.1.0",
 		"escape-string-regexp": "^1.0.5",
+		"paraquire": "0.0.23",
 		"supports-color": "^4.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
NPM ecosystem is [quite unresistant](https://github.com/ChALkeR/notes/blob/master/Gathering-weak-npm-credentials.md) against dependency attacks. It means that if a hacker gets control over one small abandoned package, the hacker gets control over all it's dependents, dependents of dependents, etc.
So, hijacking only one of small `chalk`'s dependencies will be very crucial for whole NPM ecosystem. This PR improves `chalks`'s security by jailing most dependencies into `paraquire` - secure [alternative](https://github.com/nickkolok/paraquire) for standard `require`.