### PR TITLE
Remove arbitrary value expression in the TS type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,5 +86,6 @@ export interface Chalk {
 	bgWhiteBright: Chalk;
 }
 
-declare function chalk (): any;
-export default chalk as Chalk;
+declare const chalk: Chalk
+
+export default chalk


### PR DESCRIPTION
based on upcoming breaking change in typescript 2.6 https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts

Missed this! 😬 