### PR TITLE
Fix export typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,5 +86,5 @@ export interface Chalk {
 	bgWhiteBright: Chalk;
 }
 
-declare function chalk (): any;
-export default chalk as Chalk;
+declare const chalk: Chalk;
+export default chalk;


### PR DESCRIPTION
In TypeScript 2.6 the prior typing fails to compile with

```
export default chalk as Chalk;
               ^^^^^^^^^^^^^^
The expression of an export assignment must be an identifier or qualified name in an ambient context.
```