### PR TITLE
fix(typings): fix error,  the expression of an export assignment must…

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,5 +86,5 @@ export interface Chalk {
 	bgWhiteBright: Chalk;
 }
 
-declare function chalk (): any;
-export default chalk as Chalk;
+declare const _chalk: Chalk;
+export default _chalk;


### PR DESCRIPTION
… be an identifier orqualified name in an ambient context when using TypeScript `2.6.0-rc`

More information https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts

Closes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20777