### PR TITLE
Fix windows 10 bold sequence

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@
 const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
 const supportsColor = require('supports-color');
+const os = require('os')
 
 const template = require('./templates.js');
 
 const isSimpleWindowsTerm = process.platform === 'win32' && !(process.env.TERM || '').toLowerCase().startsWith('xterm');
+const isWindows10 = process.platform === 'win32' && os.release().startsWith('10');
 
 // `supportsColor.level` → `ansiStyles.color[name]` mapping
 const levelMapping = ['ansi', 'ansi', 'ansi256', 'ansi16m'];
@@ -50,6 +52,11 @@ function Chalk(options) {
 // Use bright blue on Windows as the normal blue color is illegible
 if (isSimpleWindowsTerm) {
 	ansiStyles.blue.open = '\u001B[94m';
+}
+
+// Use full reset on Windows 10 as it does not currently support the standard bold close sequence
+if (isWindows10) {
+	ansiStyles.bold.close = '\u001B[0m';
 }
 
 for (const key of Object.keys(ansiStyles)) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
+const os = require('os');
 const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
 const supportsColor = require('supports-color');
-const os = require('os');
 
 const template = require('./templates.js');
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
 const supportsColor = require('supports-color');
-const os = require('os')
+const os = require('os');
 
 const template = require('./templates.js');
 


### PR DESCRIPTION
This is a problem I've had with a good handful of my projects. After some super deep investigation ~~/s~~, I discovered Windows 10 doesn't support the standard bold close sequence like everything else.

I added a Windows 10 check to set the closing sequence to a full reset, in the same manner the blue is corrected to bright blue.

I console logged these 3 tagged literals in both versions:
- `[{red Good morning, {bold Vap0r1ze}.}]`
- `Please {bold run} {inverse npm i {bold chalk}}`
- `__{underline You have {bold 22} credits}__`


![image](https://user-images.githubusercontent.com/20448879/33048044-e5cc5c54-ce26-11e7-84cc-b2c115115263.png)
*Top is the new version, bottom is the old*

This is how the it looks on Windows 7 & 8 (old and new)
![image](https://user-images.githubusercontent.com/20448879/33048379-8c3e3282-ce28-11e7-8da2-66683725b74a.png)

