### PR TITLE
escape-string-regexp throws - make sure value passed in str before ca…

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ if (isSimpleWindowsTerm) {
 }
 
 for (const key of Object.keys(ansiStyles)) {
-	ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
+	// Module escape-string-regexp throws if value entered is not a string.
+	if (typeof ansiStyles[key].close === 'string') {
+		ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
+	}
 
 	styles[key] = {
 		get() {
@@ -69,7 +72,10 @@ styles.visible = {
 	}
 };
 
-ansiStyles.color.closeRe = new RegExp(escapeStringRegexp(ansiStyles.color.close), 'g');
+// Module escape-string-regexp throws if value entered is not a string.
+if (typeof ansiStyles.color.close === 'string') {
+	ansiStyles.color.closeRe = new RegExp(escapeStringRegexp(ansiStyles.color.close), 'g');
+}
 for (const model of Object.keys(ansiStyles.color.ansi)) {
 	if (skipModels.has(model)) {
 		continue;
@@ -91,7 +97,11 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 	};
 }
 
-ansiStyles.bgColor.closeRe = new RegExp(escapeStringRegexp(ansiStyles.bgColor.close), 'g');
+// Module escape-string-regexp throws if value entered is not a string.
+if (typeof ansiStyles.bgColor.close === 'string') {
+	ansiStyles.bgColor.closeRe = new RegExp(escapeStringRegexp(ansiStyles.bgColor.close), 'g');
+}
+
 for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
 	if (skipModels.has(model)) {
 		continue;


### PR DESCRIPTION
This function should be used responsibly, because escape-string-regexp throws if the value is not a string. Because this module is used so deeply, this can lead to some very cryptic errors from this uncaught exception, that will leave most developers digging 3,4, 5 modules deep to figure out what's causing it.

See:

https://github.com/chalk/chalk/issues/31
https://github.com/TypeStrong/ts-node/issues/468#issuecomment-348184701

It doesn't fix the root cause of the issue, which seems to be conflicting versions of chalk being loaded at the same time in ts-node+mocha tests, but it is more responsible methinks