### PR TITLE
Add failing test for #234

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.idea/
-node_modules/
-coverage/
+node_modules
 yarn.lock
+coverage
 .nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
+.idea/
+node_modules/
+coverage/
 yarn.lock
-coverage
 .nyc_output

--- a/test/_supports-color.js
+++ b/test/_supports-color.js
@@ -1,15 +1,15 @@
 'use strict';
 const resolveFrom = require('resolve-from');
 
-module.exports = dir => {
-	require.cache[resolveFrom(dir, 'supports-color')] = {
-		exports: {
-			stdout: {
-				level: 3,
-				hasBasic: true,
-				has256: true,
-				has16m: true
-			}
-		}
-	};
+const DEFAULT = {
+	stdout: {
+		level: 3,
+		hasBasic: true,
+		has256: true,
+		has16m: true
+	}
+};
+
+module.exports = (dir, override) => {
+	require.cache[resolveFrom(dir, 'supports-color')] = {exports: override || DEFAULT};
 };

--- a/test/no-color-support.js
+++ b/test/no-color-support.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+
+// Spoof supports-color
+require('./_supports-color')(__dirname, {
+	level: 0,
+	hasBasic: false,
+	has256: false,
+	has16m: false
+});
+
+const m = require('..');
+
+test.failing('can be forced on using chalk.enabled', t => {
+	m.enabled = true;
+	t.is(m.green('hello'), '\u001B[32mhello\u001B[39m');
+});

--- a/test/no-color-support.js
+++ b/test/no-color-support.js
@@ -8,9 +8,9 @@ require('./_supports-color')(__dirname, {
 	has16m: false
 });
 
-const m = require('..');
+const chalk = require('..');
 
-test.failing('can be forced on using chalk.enabled', t => {
-	m.enabled = true;
-	t.is(m.green('hello'), '\u001B[32mhello\u001B[39m');
+test.failing('colors can be forced by using chalk.enabled', t => {
+	chalk.enabled = true;
+	t.is(chalk.green('hello'), '\u001B[32mhello\u001B[39m');
 });


### PR DESCRIPTION
## Purpose
Provide failing test for #234.

## Notes
1. **resolve-from** is a little funny. Something like https://github.com/boblauer/mock-require might be a bit simpler/clearer. (Though, I understand you're using your own stuff.)
1. Your test runner doesn't seem to have a construct for grouping tests other than files. In Mocha, if I wanted to run something to build up a single test or set of tests, I'd use a construct like this:

     ```js
     describe('outer grouping', function () {
     
         it('some test', function () {});
     
         describe('inner grouping', function () {
     
             before('build-up before tests in this group', function () {
                 // stuff
             });
     
             it('group test', function () {});
     
             after('tear-down after tests in this group', function () {
                 // stuff
             });
     
         });
     
     });
     ```
   The nested `describe` creates another "group" inside which the `before` / `beforeEach` / `after` / `afterEach` run.   
      
   In this case, I'd like to have a test or a few tests where the mocked return from **supports-color** is different. Not sure how to do that with AVA.

## Actions
What I did was create another file for tests where color is not supported. If you guys understand AVA better, maybe there's a nicer solution for this.