### PR TITLE
Update chalk to use the latest updates to supports-color

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
-const supportsColor = require('supports-color');
+const stdoutColor = require('supports-color').stdout;
 
 const template = require('./templates.js');
 
@@ -19,7 +19,7 @@ function applyOptions(obj, options) {
 	options = options || {};
 
 	// Detect level if not set manually
-	const scLevel = supportsColor ? supportsColor.level : 0;
+	const scLevel = stdoutColor ? stdoutColor.level : 0;
 	obj.level = options.level === undefined ? scLevel : options.level;
 	obj.enabled = 'enabled' in options ? options.enabled : obj.level > 0;
 }
@@ -224,5 +224,5 @@ function chalkTag(chalk, strings) {
 Object.defineProperties(Chalk.prototype, styles);
 
 module.exports = Chalk(); // eslint-disable-line new-cap
-module.exports.supportsColor = supportsColor.stdout;
+module.exports.supportsColor = stdoutColor;
 module.exports.default = module.exports; // For TypeScript

--- a/index.js
+++ b/index.js
@@ -224,5 +224,5 @@ function chalkTag(chalk, strings) {
 Object.defineProperties(Chalk.prototype, styles);
 
 module.exports = Chalk(); // eslint-disable-line new-cap
-module.exports.supportsColor = supportsColor;
+module.exports.supportsColor = supportsColor.stdout;
 module.exports.default = module.exports; // For TypeScript

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"dependencies": {
 		"ansi-styles": "^3.1.0",
 		"escape-string-regexp": "^1.0.5",
-		"supports-color": "^4.0.0"
+		"supports-color": "^5.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/test/_supports-color.js
+++ b/test/_supports-color.js
@@ -4,10 +4,12 @@ const resolveFrom = require('resolve-from');
 module.exports = dir => {
 	require.cache[resolveFrom(dir, 'supports-color')] = {
 		exports: {
-			level: 3,
-			hasBasic: true,
-			has256: true,
-			has16m: true
+			stdout: {
+				level: 3,
+				hasBasic: true,
+				has256: true,
+				has16m: true
+			}
 		}
 	};
 };


### PR DESCRIPTION
supports-color had a breaking change release a few months ago. Instead of assuming stdout as the output stream, it now allows you to check color support on any stream. It does still automatically evaluate stdout, but it is now a subproperty of what the module exports, not the actual export itself.

We can include this update as a non-breaking change in chalk though by simply exporting `chalk.supportsColor` as `supportsColor.stdout`.

Closes #240 