### PR TITLE
Add `wrapper` option

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -21,4 +21,28 @@ suite('chalk', () => {
 	bench('nested styles', () => {
 		chalk.red('the fox jumps', chalk.underline.bgBlue('over the lazy dog') + '!');
 	});
+
+	const wrappedChalk = new chalk.constructor({
+		wrapper: {
+			before: '@',
+			after: '#'
+		}
+	});
+
+	bench('wrapped single style', () => {
+		wrappedChalk.red('the fox jumps');
+	});
+
+	bench('wrapped several styles', () => {
+		wrappedChalk.blue.bgRed.bold('the fox jumps over the lazy dog');
+	});
+
+	const cachedWrapper = wrappedChalk.blue.bgRed.bold;
+	bench('cached wrapped styles', () => {
+		cachedWrapper('the fox jumps over the lazy dog');
+	});
+
+	bench('nested wrapped styles', () => {
+		wrappedChalk.red('the fox jumps', wrappedChalk.underline.bgBlue('over the lazy dog') + '!');
+	});
 });

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function applyOptions(obj, options) {
 	obj.enabled = 'enabled' in options ? options.enabled : obj.level > 0;
 
 	// By default, wrappers are empty strings
-	const defaultWrapper = {pre: '', post: ''};
+	const defaultWrapper = {before: '', after: ''};
 	obj.wrapper = typeof options.wrapper === 'object' ? Object.assign({}, defaultWrapper, options.wrapper) : defaultWrapper;
 }
 
@@ -196,8 +196,8 @@ function applyStyle() {
 		// Replace any instances already present with a re-opening code
 		// otherwise only the part of the string until said closing code
 		// will be colored, and the rest will simply be 'plain'.
-		const open = this.wrapper.pre + code.open + this.wrapper.post;
-		const close = this.wrapper.pre + code.close + this.wrapper.post;
+		const open = this.wrapper.before + code.open + this.wrapper.after;
+		const close = this.wrapper.before + code.close + this.wrapper.after;
 
 		str = open + str.replace(code.closeRe, code.open) + close;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nasc/chalk",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "Terminal string styling done right",
 	"license": "MIT",
 	"repository": "chalk/chalk",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "chalk",
+	"name": "@nasc/chalk",
 	"version": "2.3.0",
 	"description": "Terminal string styling done right",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "@nasc/chalk",
-	"version": "2.3.1",
+	"name": "chalk",
+	"version": "2.3.0",
 	"description": "Terminal string styling done right",
 	"license": "MIT",
-	"repository": "https://github.com/felipenmoura/chalk",
+	"repository": "chalk/chalk",
 	"engines": {
 		"node": ">=4"
 	},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.3.1",
 	"description": "Terminal string styling done right",
 	"license": "MIT",
-	"repository": "chalk/chalk",
+	"repository": "https://github.com/felipenmoura/chalk",
 	"engines": {
 		"node": ">=4"
 	},

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,13 @@
+
+## IMPORTANT
+
+This is the same chalk from [](https://github.com/chalk/chalk).  
+The only change made to it is the support for "wrappers" in the effects.
+
+There is a Pull Request opened to add it to Chalk, but while it is not merged (or in case it does not get approved) we can use this fork instead.
+If you want to help, you can check the [Pull Request](https://github.com/chalk/chalk/pull/252) and [the issue](https://github.com/chalk/chalk/issues/253).  
+This is being **temporarily**  published in _npm_ so we can test it out a little further.
+
 <h1 align="center">
 	<br>
 	<br>
@@ -151,7 +161,7 @@ Levels are as follows:
 
 ### chalk.wrapper
 
-The wrapper marks the unprintable characters.  
+The wrapper marks the unprintable characters from style tags.  
 A wrapper can be added to the styles, so you can escape characters or add marks to then.  
 By default, these wrappers are empty strings `""`.
 

--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,26 @@ Levels are as follows:
 2. 256 color support
 3. Truecolor support (16 million colors)
 
+### chalk.wrapper
+
+The wrapper marks the unprintable characters.  
+A wrapper can be added to the styles, so you can escape characters or add marks to then.  
+By default, these wrappers are empty strings `""`.
+
+The wrappers object has two properties, `pre` and `post`.  
+For example:
+
+```js
+const ctx = new chalk.constructor({wrapper: {
+	pre: '>',
+	post: '<',
+}});
+
+ctx.red('foo') // outputs "><foo><"
+```
+
+This can be specially useful when escaping characters, using it into a _PS1_ string or debugging and outputing it into different terminals/TTYs.
+
 ### chalk.supportsColor
 
 Detect whether the terminal [supports color](https://github.com/chalk/supports-color). Used internally and handled for you, but exposed for convenience.

--- a/readme.md
+++ b/readme.md
@@ -165,19 +165,36 @@ The wrapper marks the unprintable characters from style tags.
 A wrapper can be added to the styles, so you can escape characters or add marks to then.  
 By default, these wrappers are empty strings `""`.
 
-The wrappers object has two properties, `pre` and `post`.  
+The wrappers object has two properties, `before` and `after`.  
 For example:
 
 ```js
-const ctx = new chalk.constructor({wrapper: {
-	pre: '>',
-	post: '<',
-}});
+const ctx = new chalk.constructor({
+	wrapper: {
+		before: '>',
+		after: '<'
+	}
+});
 
-ctx.red('foo') // outputs "><foo><"
+ctx.red('foo') // outputs ">\u001B[31m<foo>\u001B[39m<"
 ```
 
-This can be specially useful when escaping characters, using it into a _PS1_ string or debugging and outputing it into different terminals/TTYs.
+This can be specially useful when escaping characters, using it into a _PS1_ string or debugging and outputing it into different terminals/TTYs.  
+That's because _PS1_ uses the number of _printable_ characters to know the length of the string and to position the cursor. If you don't mark the colour codes as "unprintable" by using `\[` and `\]`, those characteres will be used to determine the length of the string, mispositioning the cursor.
+
+```js
+const ctx = new chalk.constructor({
+	wrapper: {
+		before: '\\[',
+		after: '\\]'
+	}
+});
+
+ctx.red('foo') // outputs "\\[\u001B[31m\\]foo\\[\u001B[39m\\]" (marking the colour codes as unpritable)
+```
+
+That would output "foo" in red, as that is the printable result.
+
 
 ### chalk.supportsColor
 

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ Levels are as follows:
 2. 256 color support
 3. Truecolor support (16 million colors)
 
-### chalk.wrapper
+### wrapper
 
 The wrapper marks the unprintable characters from style tags.  
 A wrapper can be added to the styles, so you can escape characters or add marks to then.  
@@ -179,7 +179,8 @@ const ctx = new chalk.constructor({
 ctx.red('foo') // outputs ">\u001B[31m<foo>\u001B[39m<"
 ```
 
-This can be specially useful when escaping characters, using it into a _PS1_ string or debugging and outputing it into different terminals/TTYs.  
+This can be specially useful when escaping characters, using it into a _PS1_ string or outputing it into different terminals/TTYs.  
+
 That's because _PS1_ uses the number of _printable_ characters to know the length of the string and to position the cursor. If you don't mark the colour codes as "unprintable" by using `\[` and `\]`, those characteres will be used to determine the length of the string, mispositioning the cursor.
 
 ```js

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -6,7 +6,7 @@ require('./_supports-color')(__dirname);
 const m = require('..');
 
 console.log('TERM:', process.env.TERM || '[none]');
-console.log('platform:', process.platform || '[unknown]');
+console.log('Platform:', process.platform || '[unknown]');
 
 test('don\'t add any styling when called as the base function', t => {
 	t.is(m('foo'), 'foo');

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -5,12 +5,14 @@ import test from 'ava';
 // Spoof supports-color
 require('./_supports-color')(__dirname);
 
-const m = require('..');
+const Chalk = require('..');
 
-m.wrapper = {
-	pre: '@',
-	post: '#'
-};
+const m = new Chalk.constructor({
+	wrapper: {
+		before: '@',
+		after: '#'
+	}
+});
 
 test('add wrapper to underline', t => {
 	t.is(m.underline('foo'), '@\u001B[4m#foo@\u001B[24m#');

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -1,0 +1,25 @@
+// Import path from 'path';
+import test from 'ava';
+// Import execa from 'execa';
+
+// Spoof supports-color
+require('./_supports-color')(__dirname);
+
+const m = require('..');
+
+m.wrapper = {
+	pre: '@',
+	post: '#'
+};
+
+test('add wrapper to underline', t => {
+	t.is(m.underline('foo'), '@\u001B[4m#foo@\u001B[24m#');
+});
+
+test('add wrapper to color', t => {
+	t.is(m.red('foo'), '@\u001B[31m#foo@\u001B[39m#');
+});
+
+test('add wrapper to bgColor', t => {
+	t.is(m.bgRed('foo'), '@\u001B[41m#foo@\u001B[49m#');
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,12 @@ export const enum Level {
 export interface ChalkOptions {
 	enabled?: boolean;
 	level?: Level;
+	wrapper?: Wrapper;
+}
+
+export interface Wrapper {
+	pre: String,
+	post: String
 }
 
 export interface ChalkConstructor {
@@ -31,6 +37,7 @@ export interface Chalk {
 	constructor: ChalkConstructor;
 	enabled: boolean;
 	level: Level;
+	wrapper: Wrapper;
 	rgb(r: number, g: number, b: number): this;
 	hsl(h: number, s: number, l: number): this;
 	hsv(h: number, s: number, v: number): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,12 +11,10 @@ export const enum Level {
 export interface ChalkOptions {
 	enabled?: boolean;
 	level?: Level;
-	wrapper?: Wrapper;
-}
-
-export interface Wrapper {
-	pre: String,
-	post: String
+	wrapper?: {
+		before: String,
+		after: String
+	}
 }
 
 export interface ChalkConstructor {
@@ -37,7 +35,6 @@ export interface Chalk {
 	constructor: ChalkConstructor;
 	enabled: boolean;
 	level: Level;
-	wrapper: Wrapper;
 	rgb(r: number, g: number, b: number): this;
 	hsl(h: number, s: number, l: number): this;
 	hsv(h: number, s: number, v: number): this;


### PR DESCRIPTION
The wrapper marks the unprintable characters from each style tag.
This is very useful when debugging or outputing it in different terminals. You can use it to identify the unprintable characters or even to escape them.

Also added tests for it.
Added a description about it to the readme file.