### PR TITLE
fix: use export = for typescript module definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 	"files": [
 		"index.js",
 		"templates.js",
-		"types/index.d.ts"
+		"types/index.d.ts",
+		"types/options.d.ts"
 	],
 	"keywords": [
 		"color",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,36 +1,14 @@
-// Type definitions for Chalk
-// Definitions by: Thomas Sauer <https://github.com/t-sauer>
-
-export const enum Level {
-	None = 0,
-	Basic = 1,
-	Ansi256 = 2,
-	TrueColor = 3
+/// <reference path="./options.d.ts" />
+interface ChalkConstructor {
+	new (options?: Chalk.Options): Chalk;
+	(options?: Chalk.Options): Chalk;
 }
-
-export interface ChalkOptions {
-	enabled?: boolean;
-	level?: Level;
-}
-
-export interface ChalkConstructor {
-	new (options?: ChalkOptions): Chalk;
-	(options?: ChalkOptions): Chalk;
-}
-
-export interface ColorSupport {
-	level: Level;
-	hasBasic: boolean;
-	has256: boolean;
-	has16m: boolean;
-}
-
-export interface Chalk {
+interface Chalk {
 	(...text: string[]): string;
 	(text: TemplateStringsArray, ...placeholders: string[]): string;
 	constructor: ChalkConstructor;
 	enabled: boolean;
-	level: Level;
+	level: Chalk.Level;
 	rgb(r: number, g: number, b: number): this;
 	hsl(h: number, s: number, l: number): this;
 	hsv(h: number, s: number, v: number): this;
@@ -92,6 +70,10 @@ export interface Chalk {
 	readonly bgWhiteBright: this;
 }
 
-declare const chalk: Chalk & { supportsColor: ColorSupport };
+interface chalk extends Chalk {
+	supportsColor: Chalk.ColorSupport;
+	default: chalk
+}
+declare	const chalk: chalk
+export = chalk
 
-export default chalk

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,0 +1,18 @@
+declare namespace Chalk {
+	export const enum Level {
+		None = 0,
+		Basic = 1,
+		Ansi256 = 2,
+		TrueColor = 3
+	}
+	export interface Options {
+		enabled?: boolean;
+		level?: Chalk.Level;
+	}
+	export interface ColorSupport {
+		level: Level;
+		hasBasic: boolean;
+		has256: boolean;
+		has16m: boolean;
+	}
+}

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,5 @@
-import chalk, {Level} from '..';
+import chalk from '..'
+import chalktr = require('..')
 
 chalk.underline('foo');
 chalk.red('foo');
@@ -17,16 +18,16 @@ chalk.underline.red.bgGreen('foo');
 chalk.grey('foo');
 
 chalk.constructor({level: 1});
-const ctx = chalk.constructor({level: Level.TrueColor });
+const ctx = chalk.constructor({level: Chalk.Level.TrueColor });
 ctx('foo');
 ctx.red('foo');
 ctx`foo`;
 
 chalk.enabled = true;
 chalk.level = 1;
-chalk.level = Level.Ansi256;
+chalk.level = Chalk.Level.Ansi256;
 
-chalk.level === Level.Ansi256;
+chalk.level === Chalk.Level.Ansi256;
 
 let chalkInstance = new chalk.constructor();
 chalkInstance = chalk.constructor();


### PR DESCRIPTION
I actually wasn't sure if this would work but this allows the following in typescript.

```typescript
import * as chalk from 'chalk' // (new versions of ts don't let you use chalk as a function 🙌 )
import chalkDefault from 'chalk'
import chalkTypescriptRequire = require('chalk')// (legacy typescript style)
```
😑 

This will ~fix~ allow intellisense in commonjs projects in vscode (#246)

This may break some people's typescript _type_ usages.