### PR TITLE
Add Flow type definitions

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,13 +1,5 @@
 [ignore]
 .*/node_modules/.*
 
-[include]
-
-[libs]
-
-[lints]
-
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$ExpectError
-
-[strict]

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+.*/node_modules/.*
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+suppress_comment= \\(.\\|\n\\)*\\$ExpectError
+
+[strict]

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,95 @@
+// @flow
+
+type TemplateStringsArray = $ReadOnlyArray<string>;
+
+export type Level = $Values<{
+	None: 0,
+	Basic: 1,
+	Ansi256: 2,
+	TrueColor: 3
+}>;
+
+export type ChalkOptions = {|
+	enabled?: boolean,
+	level?: Level
+|};
+
+export type ColorSupport = {|
+	level: Level,
+	hasBasic: boolean,
+	has256: boolean,
+	has16m: boolean
+|};
+
+export interface Chalk {
+	(...text: string[]): string,
+	(text: TemplateStringsArray, ...placeholders: string[]): string,
+	constructor(options?: ChalkOptions): Chalk,
+	enabled: boolean,
+	level: Level,
+	rgb(r: number, g: number, b: number): Chalk,
+	hsl(h: number, s: number, l: number): Chalk,
+	hsv(h: number, s: number, v: number): Chalk,
+	hwb(h: number, w: number, b: number): Chalk,
+	bgHex(color: string): Chalk,
+	bgKeyword(color: string): Chalk,
+	bgRgb(r: number, g: number, b: number): Chalk,
+	bgHsl(h: number, s: number, l: number): Chalk,
+	bgHsv(h: number, s: number, v: number): Chalk,
+	bgHwb(h: number, w: number, b: number): Chalk,
+	hex(color: string): Chalk,
+	keyword(color: string): Chalk,
+
+	+reset: Chalk,
+	+bold: Chalk,
+	+dim: Chalk,
+	+italic: Chalk,
+	+underline: Chalk,
+	+inverse: Chalk,
+	+hidden: Chalk,
+	+strikethrough: Chalk,
+
+	+visible: Chalk,
+
+	+black: Chalk,
+	+red: Chalk,
+	+green: Chalk,
+	+yellow: Chalk,
+	+blue: Chalk,
+	+magenta: Chalk,
+	+cyan: Chalk,
+	+white: Chalk,
+	+gray: Chalk,
+	+grey: Chalk,
+	+blackBright: Chalk,
+	+redBright: Chalk,
+	+greenBright: Chalk,
+	+yellowBright: Chalk,
+	+blueBright: Chalk,
+	+magentaBright: Chalk,
+	+cyanBright: Chalk,
+	+whiteBright: Chalk,
+
+	+bgBlack: Chalk,
+	+bgRed: Chalk,
+	+bgGreen: Chalk,
+	+bgYellow: Chalk,
+	+bgBlue: Chalk,
+	+bgMagenta: Chalk,
+	+bgCyan: Chalk,
+	+bgWhite: Chalk,
+	+bgBlackBright: Chalk,
+	+bgRedBright: Chalk,
+	+bgGreenBright: Chalk,
+	+bgYellowBright: Chalk,
+	+bgBlueBright: Chalk,
+	+bgMagentaBright: Chalk,
+	+bgCyanBright: Chalk,
+	+bgWhiteBrigh: Chalk,
+
+	supportsColor: ColorSupport
+};
+
+declare var chalk: Chalk;
+
+export default chalk;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "xo && tsc --project types && flow --max-warnings 0 && nyc ava",
+		"test": "xo && tsc --project types && flow --max-warnings=0 && nyc ava",
 		"bench": "matcha benchmark.js",
 		"coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "xo && tsc --project types && nyc ava",
+		"test": "xo && tsc --project types && flow --max-warnings 0 && nyc ava",
 		"bench": "matcha benchmark.js",
 		"coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},
 	"files": [
 		"index.js",
 		"templates.js",
-		"types/index.d.ts"
+		"types/index.d.ts",
+		"index.js.flow"
 	],
 	"keywords": [
 		"color",
@@ -49,6 +50,7 @@
 		"ava": "*",
 		"coveralls": "^3.0.0",
 		"execa": "^0.9.0",
+		"flow-bin": "^0.68.0",
 		"import-fresh": "^2.0.0",
 		"matcha": "^0.7.0",
 		"nyc": "^11.0.2",
@@ -61,6 +63,9 @@
 		"envs": [
 			"node",
 			"mocha"
+		],
+		"ignores": [
+			"test/_flow.js"
 		]
 	}
 }

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -1,14 +1,13 @@
 // @flow
-
 import chalk from '..';
 
 // $ExpectError (Can't have typo in option name)
-chalk.constructor({ levl:  1 });
-chalk.constructor({ level:  1 });
+chalk.constructor({levl: 1});
+chalk.constructor({level: 1});
 
 // $ExpectError (Option must have proper type)
-new chalk.constructor({ enabled:  'true' });
-new chalk.constructor({ enabled:  true });
+new chalk.constructor({enabled: 'true'});
+new chalk.constructor({enabled: true});
 
 // $ExpectError (Can't pass in null)
 chalk.underline(null);
@@ -50,7 +49,7 @@ chalk.enabled = true;
 chalk.level = 10;
 chalk.level = 1;
 
-let chalkInstance = new chalk.constructor();
+const chalkInstance = new chalk.constructor();
 
 // $ExpectError (Can't have typo in method name)
 chalkInstance.blu('foo');
@@ -92,4 +91,4 @@ chalk.black;
 
 // $ExpectError (Can't write to readonly property)
 chalk.reset = 'foo';
-console.log(chalk.reset)
+console.log(chalk.reset);

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -1,0 +1,95 @@
+// @flow
+
+import chalk from '..';
+
+// $ExpectError (Can't have typo in option name)
+chalk.constructor({ levl:  1 });
+chalk.constructor({ level:  1 });
+
+// $ExpectError (Option must have proper type)
+new chalk.constructor({ enabled:  'true' });
+new chalk.constructor({ enabled:  true });
+
+// $ExpectError (Can't pass in null)
+chalk.underline(null);
+chalk.underline('foo');
+
+// $ExpectError (Can't have typo in chalk method)
+chalk.rd('foo');
+chalk.red('foo');
+
+// $ExpectError (Can't have typo in chalk method)
+chalk.gren`foo`;
+chalk.green`foo`;
+
+// $ExpectError (Can't have typo in chalk method)
+chalk.red.bgBlu.underline('foo');
+chalk.red.bgBlue.underline('foo');
+
+// $ExpectError (Level must be 0, 1, 2, or 3)
+const badCtx = chalk.constructor({level: 4});
+const ctx = chalk.constructor({level: 3});
+
+// $ExpectError (Can't pass in null)
+ctx(null);
+ctx('foo');
+
+// $ExpectError (Can't have typo in method name)
+ctx.gry('foo');
+ctx.grey('foo');
+
+// $ExpectError (Can't have typo in method name)
+ctx`foo`.value();
+ctx`foo`.valueOf();
+
+// $ExpectError (Can't have typo in property name)
+chalk.abled = true;
+chalk.enabled = true;
+
+// $ExpectError (Can't use invalid Level for property setter)
+chalk.level = 10;
+chalk.level = 1;
+
+let chalkInstance = new chalk.constructor();
+
+// $ExpectError (Can't have typo in method name)
+chalkInstance.blu('foo');
+chalkInstance.blue('foo');
+chalkInstance`foo`;
+
+// $ExpectError (Can't have typo in method name)
+chalk.keywrd('orange').bgBlue('foo');
+chalk.keyword('orange').bgBlue('foo');
+
+// $ExpectError (rgb should take in 3 numbers)
+chalk.rgb(1, 14).bgBlue('foo');
+chalk.rgb(1, 14, 9).bgBlue('foo');
+
+// $ExpectError (hsl should take in 3 numbers)
+chalk.hsl(1, 14, '9').bgBlue('foo');
+chalk.hsl(1, 14, 9).bgBlue('foo');
+
+// $ExpectError (hsv should take in 3 numbers)
+chalk.hsv(1, 14).bgBlue('foo');
+chalk.hsv(1, 14, 9).bgBlue('foo');
+
+// $ExpectError (hwb should take in 3 numbers)
+chalk.hwb(1, 14).bgBlue('foo');
+chalk.hwb(1, 14, 9).bgBlue('foo');
+
+// $ExpectError (Can't have typo in method name)
+chalk.visibl('foo');
+chalk.visible('foo');
+
+// $ExpectError (Can't have typo in method name)
+chalk.red.visibl('foo');
+chalk.red.visible('foo');
+chalk.visible.red('foo');
+
+// $ExpectError (Can't write to readonly property)
+chalk.black = 'foo';
+chalk.black;
+
+// $ExpectError (Can't write to readonly property)
+chalk.reset = 'foo';
+console.log(chalk.reset)


### PR DESCRIPTION
Closes #165.

It would be great if anyone with Flow knowledge could review this.

And to explain how the test works, basically any comment that has `$ExpectError` in it requires that the line directly below it to have a type error. If there is no type error in the line below `$ExpectError`, the test will fail. The reverse is also true – if there is a type error with no `$ExpectError` above it, the test will fail.

Let me know if there is anything you would like for me to change about this!