### PR TITLE
[flow] add compatibility with node require()

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -90,6 +90,4 @@ export interface Chalk {
 	supportsColor: ColorSupport
 };
 
-declare var chalk: Chalk;
-
-export default chalk;
+declare module.exports: Chalk;


### PR DESCRIPTION
Fixes #264. I forgot to take into account that not everyone who uses Flow uses ES Modules, so using a CommonJS export will you to use both:

```js
const chalk = require('chalk');
```

as well as 

```js
import chalk from 'chalk';
```

It is fine to leave the `export` on the types however. Regardless if you're using CJS or ESM, you will be able to use `import type` syntax such as:

```ts
import type { Level } from 'chalk';
```

This will work even if you're using `require` because that flow import syntax is just stripped away with Babel just like the rest of the types.

I didn't add an additional test file which uses the `require` syntax, but I tested it locally and it worked. If you want me to add a `_flow-node.js` test file or something let me know and I can add that as well.