### PR TITLE
Improve Flow type definition for CommonJS interop

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -90,6 +90,4 @@ export interface Chalk {
 	supportsColor: ColorSupport
 };
 
-declare var chalk: Chalk;
-
-export default chalk;
+declare module.exports: Chalk;


### PR DESCRIPTION
Flow's common js interop only works one way, CJS -> ESM

Right now:

```js
import chalk from 'chalk';
chalk.red('hi'); // works.
```

```js
const chalk = require('chalk');
chalk.red('hi'); // error!
```
