### PR TITLE
Fix destructuring hex and bgHex (#271)

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 	styles[model] = {
 		get() {
 			const level = this.level;
+			const self = this;
 			return function () {
 				const open = ansiStyles.color[levelMapping[level]][model].apply(null, arguments);
 				const codes = {
@@ -85,7 +86,7 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 					close: ansiStyles.color.close,
 					closeRe: ansiStyles.color.closeRe
 				};
-				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+				return build.call(self, self._styles ? self._styles.concat(codes) : [codes], self._empty, model);
 			};
 		}
 	};
@@ -101,6 +102,7 @@ for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
 	styles[bgModel] = {
 		get() {
 			const level = this.level;
+			const self = this;
 			return function () {
 				const open = ansiStyles.bgColor[levelMapping[level]][model].apply(null, arguments);
 				const codes = {
@@ -108,7 +110,7 @@ for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
 					close: ansiStyles.bgColor.close,
 					closeRe: ansiStyles.bgColor.closeRe
 				};
-				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+				return build.call(self, self._styles ? self._styles.concat(codes) : [codes], self._empty, model);
 			};
 		}
 	};

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -98,3 +98,10 @@ test('don\'t emit RGB codes if level is 0', t => {
 	t.is(new m.constructor({level: 0}).hex('#FF0000')('hello'), 'hello');
 	t.is(new m.constructor({level: 0}).bgHex('#FF0000')('hello'), 'hello');
 });
+
+test('support destructure hex/bgHex function', t => {
+	const {hex} = m.constructor({level: 2});
+	t.is(hex('#FF0000')('hello'), '\u001B[38;5;196mhello\u001B[39m');
+	const {bgHex} = m.constructor({level: 2});
+	t.is(bgHex('#FF0000')('hello'), '\u001B[48;5;196mhello\u001B[49m');
+});


### PR DESCRIPTION
This PR fixes #271. Now it is fine to destructure functions like `hex` or `bgHex`. I also added tests.