### PR TITLE
Remove const enum from Level TypeScript definition (#295)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for Chalk
 // Definitions by: Thomas Sauer <https://github.com/t-sauer>
 
-export const enum Level {
+export enum Level {
 	None = 0,
 	Basic = 1,
 	Ansi256 = 2,

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -4,6 +4,7 @@
 		"target": "es6",
 		"noImplicitAny": true,
 		"noEmit": true,
-		"allowJs": true
+		"allowJs": true,
+		"isolatedModules": true
 	}
 }


### PR DESCRIPTION
Fixes #295.

I changed the type definition for `Level` to use a naked enum. This makes the type definitions compatible with Babel compiled TypeScript.

I enabled the `isolatedModules` compiler flag so that the introduction of incompatible code will be caught as an error.

`const enum`, if I'm not mistaken, only controls emit behavior. Changing it to a normal `enum` in the type definitions should not change the semantic meaning.
