### PR TITLE
Remove dependency on escape-string-regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const skipModels = new Set(['gray']);
 const styles = Object.create(null);
 
 function escapeStringRegexp(str) {
- return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function applyOptions(obj, options = {}) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
 const stdoutColor = require('supports-color').stdout;
 
@@ -14,6 +13,10 @@ const levelMapping = ['ansi', 'ansi', 'ansi256', 'ansi16m'];
 const skipModels = new Set(['gray']);
 
 const styles = Object.create(null);
+
+function escapeStringRegexp(str) {
+ return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 function applyOptions(obj, options = {}) {
 	if (options.level > 3 || options.level < 0) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.1",
-		"escape-string-regexp": "^1.0.5",
 		"supports-color": "^5.5.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
As `chalk` is used by thousands of people daily and provided that `escape-string-regexp` is a very simple package, I went ahead and removed the extra dependency from `package.json`, replacing it with an inline function. Feel free to close, if you believe this could introduce problems down the line, as it is an opinionated change.