### PR TITLE
Fix ignore chars regex flags in rainbow example

### DIFF
--- a/examples/rainbow.js
+++ b/examples/rainbow.js
@@ -1,7 +1,7 @@
 'use strict';
 const chalk = require('..');
 
-const ignoreChars = /[^!-~]/;
+const ignoreChars = /[^!-~]/g;
 
 function rainbow(str, offset) {
 	if (!str || str.length === 0) {


### PR DESCRIPTION
This PR fixes the `ignoreChars` regular expression object to use global matching, rather than stopping after the first match.

Without the global flag, the following line:

https://github.com/chalk/chalk/blob/1542c85f1b31867f387a322be7396ce069adfe26/examples/rainbow.js#L11

would compute a length of 47 because the string after replacement would be `"Wehope you enjoy the new version of Chalk 2! <3"`; only the first match (a space) was removed.
