### PR TITLE
Strict mode in Flow definition

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 type TemplateStringsArray = $ReadOnlyArray<string>;
 


### PR DESCRIPTION
Converts the Flow definition for `chalk` to use `@flow strict`.

This makes it so that projects using `chalk` can use `@flow strict` (which requires all dependencies to be recursively strict).