### PR TITLE
fix(ts): normalize default commonjs export

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,4 +222,3 @@ Object.defineProperties(Chalk.prototype, styles);
 
 module.exports = Chalk(); // eslint-disable-line new-cap
 module.exports.supportsColor = stdoutColor;
-module.exports.default = module.exports; // For TypeScript

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,31 +1,31 @@
 // Type definitions for Chalk
 // Definitions by: Thomas Sauer <https://github.com/t-sauer>
 
-export const enum Level {
+declare enum Level {
 	None = 0,
 	Basic = 1,
 	Ansi256 = 2,
 	TrueColor = 3
 }
 
-export interface ChalkOptions {
+interface ChalkOptions {
 	enabled?: boolean;
 	level?: Level;
 }
 
-export interface ChalkConstructor {
+interface ChalkConstructor {
 	new (options?: ChalkOptions): Chalk;
 	(options?: ChalkOptions): Chalk;
 }
 
-export interface ColorSupport {
+interface ColorSupport {
 	level: Level;
 	hasBasic: boolean;
 	has256: boolean;
 	has16m: boolean;
 }
 
-export interface Chalk {
+interface Chalk {
 	(...text: string[]): string;
 	(text: TemplateStringsArray, ...placeholders: string[]): string;
 	constructor: ChalkConstructor;
@@ -92,6 +92,11 @@ export interface Chalk {
 	readonly bgWhiteBright: this;
 }
 
-declare const chalk: Chalk & { supportsColor: ColorSupport };
+interface PublicTypes {
+	supportsColor: ColorSupport;
+	Level: typeof Level;
+}
 
-export default chalk
+declare const chalk: Chalk & PublicTypes;
+
+export = chalk

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,8 +2,9 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es6",
-		"noImplicitAny": true,
+		"strict": true,
 		"noEmit": true,
-		"allowJs": true
+		"allowJs": true,
+		"esModuleInterop": true
 	}
 }


### PR DESCRIPTION
currently when using chalk with typescript or `//@ts-check` within vanilla js, user has to import `default` which is indeed very strange and non standard api. 

This PR fixes that issue for both vanilla JS users using TS to check js files and TS users

*Before:*

```js
// @ts-check
const {default:chalk} = require('chalk')
```

*After:*
```js
// @ts-check
const chalk = require('chalk')
```