### PR TITLE
Add `stderr` support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,6 +271,6 @@ export interface Chalk {
  * Order doesn't matter, and later styles take precedent in case of a conflict.
  * This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
  */
-declare const chalk: Chalk & { supportsColor: ColorSupport };
+declare const chalk: Chalk & { supportsColor: false | ColorSupport };
 
 export default chalk;

--- a/index.js.flow
+++ b/index.js.flow
@@ -14,7 +14,7 @@ export type Options = {|
 	level?: Level
 |};
 
-export type ColorSupport = {|
+export type ColorSupport = false | {|
 	level: Level,
 	hasBasic: boolean,
 	has256: boolean,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,7 +2,7 @@ import {expectType} from 'tsd-check';
 import chalk, {Level, Chalk, ColorSupport} from '.';
 
 // - Helpers -
-type colorReturn = Chalk & {supportsColor: ColorSupport};
+type colorReturn = Chalk & {supportsColor: false | ColorSupport};
 
 // - Level -
 expectType<number>(Level.None);
@@ -11,9 +11,9 @@ expectType<number>(Level.Ansi256);
 expectType<number>(Level.TrueColor);
 
 // - supportsColor -
-expectType<boolean>(chalk.supportsColor.hasBasic);
-expectType<boolean>(chalk.supportsColor.has256);
-expectType<boolean>(chalk.supportsColor.has16m);
+expectType<boolean>(chalk.supportsColor && chalk.supportsColor.hasBasic);
+expectType<boolean>(chalk.supportsColor && chalk.supportsColor.has256);
+expectType<boolean>(chalk.supportsColor && chalk.supportsColor.has16m);
 
 // - Chalk -
 // -- Constructor --

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"index.js",
 		"templates.js",
 		"index.d.ts",
-		"index.js.flow"
+		"index.js.flow",
+		"stderr.js",
+		"stderr.d.ts"
 	],
 	"keywords": [
 		"color",

--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,6 @@ console.log(chalk.blue('Hello world!'));
 
 Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
 
-For output to **stderr** (like `console.error`) use `require('chalk/stderr')`.
-
 ```js
 const chalk = require('chalk');
 const log = console.log;
@@ -178,7 +176,7 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 
 ## Output to `stderr`
 
-Output intended for `stderr` should use `require('chalk/stderr')` instead of `require('chalk')`. It has an identical API, but correctly detects color support for the `stderr` stream.
+Output intended for [`stderr`](https://nodejs.org/api/process.html#process_process_stderr) (e.g. `console.error()`) should use `require('chalk/stderr')` instead of `require('chalk')`. It has an identical API, but correctly detects color support for the `stderr` stream.
 
 
 ## Styles

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ console.log(chalk.blue('Hello world!'));
 
 Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
 
-For output to ***stderr*** (like `console.error` or `console.warn`) use `require('chalk/stderr')`
+For output to **stderr** (like `console.error`) use `require('chalk/stderr')`.
 
 ```js
 const chalk = require('chalk');
@@ -175,16 +175,11 @@ Can be overridden by the user with the flags `--color` and `--no-color`. For sit
 
 Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 
-### `chalk` vs `chalk/stderr`
 
-For simplicity of use, there is `chalk/stderr` export.
-Everything exported from `chalk` is also exported from `chalk/stderr`.
-Only differense is actual value of `supportsColor` exported:
+## Output to `stderr`
 
-- for `chalk` import, `supportsColor` depends on `stdout`
-- for `chalk/stderr` value depends on `stderr`
+Output intended for `stderr` should use `require('chalk/stderr')` instead of `require('chalk')`. It has an identical API, but correctly detects color support for the `stderr` stream.
 
-This may differ if one of the standart outputs is redirected and the other is not.
 
 ## Styles
 

--- a/readme.md
+++ b/readme.md
@@ -55,16 +55,14 @@ $ npm install chalk
 ## Usage
 
 ```js
-// for stdout: console.log, console.info, console.debug
 const chalk = require('chalk');
-// for stderr: console.error, console.warn
-const cherr = require('chalk/stderr');
 
 console.log(chalk.blue('Hello world!'));
-console.error(cherr.red('Oh, colored error!'));
 ```
 
 Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
+
+For output to ***stderr*** (like `console.error` or `console.warn`) use `require('chalk/stderr')`
 
 ```js
 const chalk = require('chalk');

--- a/readme.md
+++ b/readme.md
@@ -55,9 +55,13 @@ $ npm install chalk
 ## Usage
 
 ```js
+// for stdout: console.log, console.info, console.debug
 const chalk = require('chalk');
+// for stderr: console.error, console.warn
+const cherr = require('chalk/stderr');
 
 console.log(chalk.blue('Hello world!'));
+console.error(cherr.red('Oh, colored error!'));
 ```
 
 Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
@@ -173,6 +177,16 @@ Can be overridden by the user with the flags `--color` and `--no-color`. For sit
 
 Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 
+### `chalk` vs `chalk/stderr`
+
+For simplicity of use, there is `chalk/stderr` export.
+Everything exported from `chalk` is also exported from `chalk/stderr`.
+Only differense is actual value of `supportsColor` exported:
+
+- for `chalk` import, `supportsColor` depends on `stdout`
+- for `chalk/stderr` value depends on `stderr`
+
+This may differ if one of the standart outputs is redirected and the other is not.
 
 ## Styles
 

--- a/stderr.d.ts
+++ b/stderr.d.ts
@@ -2,5 +2,5 @@ import Chalk from '.';
 
 declare const chalk: Chalk;
 
-export * from '.';
 export default chalk;
+export * from '.';

--- a/stderr.d.ts
+++ b/stderr.d.ts
@@ -1,0 +1,6 @@
+import Chalk from '.';
+
+declare const chalk: Chalk;
+
+export * from '.';
+export default chalk;

--- a/stderr.js
+++ b/stderr.js
@@ -1,0 +1,7 @@
+'use strict';
+const {stderr: stderrColor} = require('supports-color');
+const {constructor: Chalk} = require('.');
+
+module.exports = new Chalk({level: stderrColor ? stderrColor.level : 0});
+module.exports.supportsColor = stderrColor;
+module.exports.default = module.exports; // For TypeScript

--- a/stderr.js.flow
+++ b/stderr.js.flow
@@ -1,0 +1,5 @@
+// @flow strict
+
+import { Chalk } from './index';
+
+declare module.exports: Chalk;

--- a/stderr.js.flow
+++ b/stderr.js.flow
@@ -1,5 +1,4 @@
 // @flow strict
-
-import { Chalk } from './index';
+import {Chalk} from '.';
 
 declare module.exports: Chalk;

--- a/stderr.test-d.ts
+++ b/stderr.test-d.ts
@@ -1,0 +1,27 @@
+import {expectType} from 'tsd-check';
+import cherr, {Level, Chalk, ColorSupport} from './stderr';
+
+// - Helpers -
+type colorReturn = Chalk & {supportsColor: ColorSupport};
+
+// - supportsColor -
+expectType<boolean>(cherr.supportsColor.hasBasic);
+expectType<boolean>(cherr.supportsColor.has256);
+expectType<boolean>(cherr.supportsColor.has16m);
+
+// - Chalk -
+// -- Constructor --
+expectType<Chalk>(new cherr.constructor({level: 1}));
+
+// -- Properties --
+expectType<boolean>(cherr.enabled);
+expectType<Level>(cherr.level);
+
+// -- Template literal --
+expectType<string>(cherr``);
+
+// -- Color methods --
+expectType<colorReturn>(cherr.hex('#DEADED'));
+
+// -- Complex --
+expectType<string>(cherr.underline.red.bgGreen('foo'));

--- a/stderr.test-d.ts
+++ b/stderr.test-d.ts
@@ -1,27 +1,27 @@
 import {expectType} from 'tsd-check';
-import cherr, {Level, Chalk, ColorSupport} from './stderr';
+import chalkStderr, {Level, Chalk, ColorSupport} from './stderr';
 
 // - Helpers -
 type colorReturn = Chalk & {supportsColor: ColorSupport};
 
 // - supportsColor -
-expectType<boolean>(cherr.supportsColor.hasBasic);
-expectType<boolean>(cherr.supportsColor.has256);
-expectType<boolean>(cherr.supportsColor.has16m);
+expectType<boolean>(chalkStderr.supportsColor.hasBasic);
+expectType<boolean>(chalkStderr.supportsColor.has256);
+expectType<boolean>(chalkStderr.supportsColor.has16m);
 
 // - Chalk -
 // -- Constructor --
-expectType<Chalk>(new cherr.constructor({level: 1}));
+expectType<Chalk>(new chalkStderr.constructor({level: 1}));
 
 // -- Properties --
-expectType<boolean>(cherr.enabled);
-expectType<Level>(cherr.level);
+expectType<boolean>(chalkStderr.enabled);
+expectType<Level>(chalkStderr.level);
 
 // -- Template literal --
-expectType<string>(cherr``);
+expectType<string>(chalkStderr``);
 
 // -- Color methods --
-expectType<colorReturn>(cherr.hex('#DEADED'));
+expectType<colorReturn>(chalkStderr.hex('#DEADED'));
 
 // -- Complex --
-expectType<string>(cherr.underline.red.bgGreen('foo'));
+expectType<string>(chalkStderr.underline.red.bgGreen('foo'));

--- a/test/_fixture.js
+++ b/test/_fixture.js
@@ -1,6 +1,6 @@
 'use strict';
 const chalk = require('..');
-const cherr = require('../stderr');
+const chalkStderr = require('../stderr');
 
 console.log(chalk.hex('#ff6159')('test'));
-console.error(cherr.hex('#ffe861')('test stderr'));
+console.error(chalkStderr.hex('#ffe861')('test stderr'));

--- a/test/_fixture.js
+++ b/test/_fixture.js
@@ -1,4 +1,6 @@
 'use strict';
 const chalk = require('..');
+const cherr = require('../stderr');
 
 console.log(chalk.hex('#ff6159')('test'));
+console.error(cherr.hex('#ffe861')('test stderr'));

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -89,3 +89,6 @@ chalk.black;
 // $ExpectError (Can't write to readonly property)
 chalk.reset = 'foo';
 console.log(chalk.reset);
+
+// `chalk/stderr` works
+chalkStderr.blue('foo');

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -1,6 +1,6 @@
 // @flow
 import chalk from '..';
-import cherr from '../stderr';
+import chalkStderr from '../stderr';
 
 // $ExpectError (Can't have typo in option name)
 chalk.constructor({levl: 1});
@@ -15,8 +15,8 @@ chalk.underline(null);
 chalk.underline('foo');
 
 // $ExpectError (Can't pass in null)
-cherr.underline(null);
-cherr.underline('foo');
+chalkStderr.underline(null);
+chalkStderr.underline('foo');
 
 // $ExpectError (Can't have typo in chalk method)
 chalk.rd('foo');

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -10,6 +10,10 @@ chalk.constructor({level: 1});
 new chalk.constructor({enabled: 'true'});
 new chalk.constructor({enabled: true});
 
+// $ExpectError (Can't pass in null)
+chalk.underline(null);
+chalk.underline('foo');
+
 // $ExpectError (Can't have typo in chalk method)
 chalk.rd('foo');
 chalk.red('foo');

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -10,14 +10,6 @@ chalk.constructor({level: 1});
 new chalk.constructor({enabled: 'true'});
 new chalk.constructor({enabled: true});
 
-// $ExpectError (Can't pass in null)
-chalk.underline(null);
-chalk.underline('foo');
-
-// $ExpectError (Can't pass in null)
-chalkStderr.underline(null);
-chalkStderr.underline('foo');
-
 // $ExpectError (Can't have typo in chalk method)
 chalk.rd('foo');
 chalk.red('foo');

--- a/test/_flow.js
+++ b/test/_flow.js
@@ -1,5 +1,6 @@
 // @flow
 import chalk from '..';
+import cherr from '../stderr';
 
 // $ExpectError (Can't have typo in option name)
 chalk.constructor({levl: 1});
@@ -12,6 +13,10 @@ new chalk.constructor({enabled: true});
 // $ExpectError (Can't pass in null)
 chalk.underline(null);
 chalk.underline('foo');
+
+// $ExpectError (Can't pass in null)
+cherr.underline(null);
+cherr.underline('foo');
 
 // $ExpectError (Can't have typo in chalk method)
 chalk.rd('foo');

--- a/test/_supports-color.js
+++ b/test/_supports-color.js
@@ -7,6 +7,12 @@ const DEFAULT = {
 		hasBasic: true,
 		has256: true,
 		has16m: true
+	},
+	stderr: {
+		level: 3,
+		hasBasic: true,
+		has256: true,
+		has16m: true
 	}
 };
 

--- a/test/stderr.js
+++ b/test/stderr.js
@@ -1,0 +1,27 @@
+import path from 'path';
+import test from 'ava';
+import execa from 'execa';
+
+// Spoof supports-color
+require('./_supports-color')(__dirname);
+
+const cherr = require('../stderr');
+
+test('stderr don\'t output colors when manually disabled', t => {
+	cherr.enabled = false;
+	t.is(cherr.red('foo'), 'foo');
+	cherr.enabled = true;
+});
+
+test('stderr enable/disable colors based on overall chalk enabled property, not individual instances', t => {
+	cherr.enabled = false;
+	const {red} = cherr;
+	t.false(red.enabled);
+	cherr.enabled = true;
+	t.true(red.enabled);
+	cherr.enabled = true;
+});
+
+test('disable colors if they are not supported', async t => {
+	t.is(await execa.stderr('node', [path.join(__dirname, '_fixture')]), 'test stderr');
+});

--- a/test/stderr.js
+++ b/test/stderr.js
@@ -5,21 +5,21 @@ import execa from 'execa';
 // Spoof supports-color
 require('./_supports-color')(__dirname);
 
-const cherr = require('../stderr');
+const chalkStderr = require('../stderr');
 
 test('stderr don\'t output colors when manually disabled', t => {
-	cherr.enabled = false;
-	t.is(cherr.red('foo'), 'foo');
-	cherr.enabled = true;
+	chalkStderr.enabled = false;
+	t.is(chalkStderr.red('foo'), 'foo');
+	chalkStderr.enabled = true;
 });
 
 test('stderr enable/disable colors based on overall chalk enabled property, not individual instances', t => {
-	cherr.enabled = false;
-	const {red} = cherr;
+	chalkStderr.enabled = false;
+	const {red} = chalkStderr;
 	t.false(red.enabled);
-	cherr.enabled = true;
+	chalkStderr.enabled = true;
 	t.true(red.enabled);
-	cherr.enabled = true;
+	chalkStderr.enabled = true;
 });
 
 test('disable colors if they are not supported', async t => {


### PR DESCRIPTION
This add support for `require('chalk/stderr')`

Fixes #301 
Fixes #318

- [x] tests
- [x] documentation (may need rewording)
- [x] typescript definition (may be incorrect), see comment
- [x] flow definition