### PR TITLE
Remove the blue color workaround for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,6 @@ function Chalk(options) {
 	applyOptions(this, options);
 }
 
-// Use bright blue on Windows as the normal blue color is illegible
-if (isSimpleWindowsTerm) {
-	ansiStyles.blue.open = '\u001B[94m';
-}
-
 for (const key of Object.keys(ansiStyles)) {
 	ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
 

--- a/test/windows.js
+++ b/test/windows.js
@@ -29,18 +29,6 @@ test.beforeEach(() => {
 test('detect a simple term if TERM isn\'t set', t => {
 	delete process.env.TERM;
 	const chalk = importFresh('..');
-	t.is(chalk.blue('foo'), '\u001B[94mfoo\u001B[39m');
-});
-
-test('replace blue foreground color in cmd.exe', t => {
-	process.env.TERM = 'dumb';
-	const chalk = importFresh('..');
-	t.is(chalk.blue('foo'), '\u001B[94mfoo\u001B[39m');
-});
-
-test('don\'t replace blue foreground color in xterm based terminals', t => {
-	process.env.TERM = 'xterm-256color';
-	const chalk = importFresh('..');
 	t.is(chalk.blue('foo'), '\u001B[34mfoo\u001B[39m');
 });
 
@@ -59,5 +47,5 @@ test('apply dimmed styling on xterm compatible terminals', t => {
 test('apply dimmed styling on strings of other colors', t => {
 	process.env.TERM = 'dumb';
 	const chalk = importFresh('..');
-	t.is(chalk.blue.dim('foo'), '\u001B[94m\u001B[2mfoo\u001B[22m\u001B[39m');
+	t.is(chalk.blue.dim('foo'), '\u001B[34m\u001B[2mfoo\u001B[22m\u001B[39m');
 });


### PR DESCRIPTION
The illegible blue color has been fixed in Windows 10 build 16257: https://blogs.msdn.microsoft.com/commandline/2017/08/02/updating-the-windows-console-colors/

The workaround causes all kinds of problems, so better to remove it than adding conditionals for older Windows versions.

Fixes #329