### PR TITLE
Add Azure Pipelines for CI (Linux, Mac, and Windows)

### DIFF
--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -1,0 +1,34 @@
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: $(NODE_VERSION)
+  displayName: 'Install Node.js'
+
+- script: npm install
+  displayName: 'Install dependencies (npm install)'
+
+- script: npm run test:lint
+  displayName: 'Run lint check'
+
+- script: npm run test:validate
+  displayName: 'Run TypeScript Declaration / Flow checks'
+
+- bash: |
+    npm install -g tap-junit
+    npm run test:ava | tap-junit > test-results.xml
+  env:
+    CI: true
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: JUnit
+    testResultsFiles: './test-results.xml'
+    testRunTitle: '$(System.JobIdentifier) tests'
+  displayName: 'Publish test results'
+
+- script: npm run report-coverage
+  env:
+    COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN_SECRET)
+  continueOnError: true
+  displayName: 'Publish coverage results'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,35 @@
+trigger:
+- master
+
+jobs:
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        Node8:
+          NODE_VERSION: '8.x'
+        Node10:
+          NODE_VERSION: '10.x'
+    steps:
+    - template: .azure-pipelines-steps.yml
+
+  - job: Windows
+    pool:
+      vmImage: vs2017-win2016
+    strategy:
+      matrix:
+        Node10:
+          NODE_VERSION: '10.x'
+    steps:
+    - template: .azure-pipelines-steps.yml
+
+  - job: macOS
+    pool:
+      vmImage: macos-10.13
+    strategy:
+      matrix:
+        Node10:
+          NODE_VERSION: '10.x'
+    steps:
+    - template: .azure-pipelines-steps.yml

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,3 @@
+export default function config() {
+	return process.env.CI ? {tap: true} : {};
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,12 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && nyc ava && tsd-check && flow",
-		"bench": "matcha benchmark.js"
+		"test:lint": "xo",
+		"test:ava": "nyc ava",
+		"test:validate": "tsd-check && flow",
+		"test": "npm-run-all test:*",
+		"bench": "matcha benchmark.js",
+		"report-coverage": "nyc report --reporter=text-lcov | coveralls"
 	},
 	"files": [
 		"index.js",
@@ -53,7 +57,8 @@
 		"flow-bin": "^0.94.0",
 		"import-fresh": "^3.0.0",
 		"matcha": "^0.7.0",
-		"nyc": "^13.3.0",
+		"npm-run-all": "^4.1.5",
+		"nyc": "^13.1.0",
 		"resolve-from": "^4.0.0",
 		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 > Terminal string styling done right
 
 [![Build Status](https://travis-ci.org/chalk/chalk.svg?branch=master)](https://travis-ci.org/chalk/chalk) [![Coverage Status](https://coveralls.io/repos/github/chalk/chalk/badge.svg?branch=master)](https://coveralls.io/github/chalk/chalk?branch=master) [![npm dependents](https://badgen.net/npm/dependents/chalk)](https://www.npmjs.com/package/chalk?activeTab=dependents) [![Downloads](https://badgen.net/npm/dt/chalk)](https://www.npmjs.com/package/chalk) [![](https://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo) ![TypeScript- and Flow-ready](https://img.shields.io/npm/types/chalk.svg)
+[![Azure Pipelines Build Status](https://dev.azure.com/chalk-ci/chalk/_apis/build/status/chalk?branchName=master)](https://dev.azure.com/chalk-ci/chalk/_build/latest?definitionId=1&branchName=master)
 
 <img src="https://cdn.jsdelivr.net/gh/chalk/ansi-styles@8261697c95bf34b6c7767e2cbe9941a851d59385/screenshot.svg" width="900">
 


### PR DESCRIPTION
This PR adds support for Azure Pipelines to perform CI and PR builds for chalk on Linux, Mac, and Windows. Here is the pipeline I created for my fork: https://dev.azure.com/chalk-ci/chalk/_build/results?buildId=9
 
Azure Pipelines has rich test reporting which works well with commonly used test runners. Here is how test results for chalk get reported:
 
![chalk-tests](https://user-images.githubusercontent.com/47400341/54204065-db3ed280-44a9-11e9-81fc-5aca67cc67d2.jpg)

The pipeline is currently configured to run only Node 10 on Windows and Mac, but I can add more versions on any of the platforms. 

If you are not aware, Azure Pipelines provides open source projects 10 parallel build pipelines with unlimited minutes for Linux, Mac, and Windows.

Full disclosure: I am a Program Manager at Azure Pipelines. Please let me know if you have any questions or suggestion about this PR or about Azure Pipelines in general.
