### PR TITLE
Export Color type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,45 @@ export interface ColorSupport {
 	has16m: boolean;
 }
 
+/**
+ * Available colors for use
+ */
+export type Color =
+	"black"
+	| "red"
+	| "green"
+	| "yellow"
+	| "blue"
+	| "magenta"
+	| "cyan"
+	| "white"
+	| "gray"
+	| "grey"
+	| "blackBright"
+	| "redBright"
+	| "greenBright"
+	| "yellowBright"
+	| "blueBright"
+	| "magentaBright"
+	| "cyanBright"
+	| "whiteBright"
+	| "bgBlack"
+	| "bgRed"
+	| "bgGreen"
+	| "bgYellow"
+	| "bgBlue"
+	| "bgMagenta"
+	| "bgCyan"
+	| "bgWhite"
+	| "bgBlackBright"
+	| "bgRedBright"
+	| "bgGreenBright"
+	| "bgYellowBright"
+	| "bgBlueBright"
+	| "bgMagentaBright"
+	| "bgCyanBright"
+	| "bgWhiteBright";
+
 export interface Chalk {
 	(...text: unknown[]): string;
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -21,6 +21,45 @@ export type ColorSupport = {|
 	has16m: boolean
 |};
 
+/**
+ * Available colors for use
+ */
+export type Color =
+	"black"
+	| "red"
+	| "green"
+	| "yellow"
+	| "blue"
+	| "magenta"
+	| "cyan"
+	| "white"
+	| "gray"
+	| "grey"
+	| "blackBright"
+	| "redBright"
+	| "greenBright"
+	| "yellowBright"
+	| "blueBright"
+	| "magentaBright"
+	| "cyanBright"
+	| "whiteBright"
+	| "bgBlack"
+	| "bgRed"
+	| "bgGreen"
+	| "bgYellow"
+	| "bgBlue"
+	| "bgMagenta"
+	| "bgCyan"
+	| "bgWhite"
+	| "bgBlackBright"
+	| "bgRedBright"
+	| "bgGreenBright"
+	| "bgYellowBright"
+	| "bgBlueBright"
+	| "bgMagentaBright"
+	| "bgCyanBright"
+	| "bgWhiteBright";
+
 export interface Chalk {
 	(...text: string[]): string,
 	(text: TemplateStringsArray, ...placeholders: mixed[]): string,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd-check';
-import chalk, {Level, Chalk, ColorSupport} from '.';
+import chalk, {Level, Chalk, ColorSupport,Color} from '.';
 
 // - Helpers -
 type colorReturn = Chalk & {supportsColor: ColorSupport};
@@ -14,6 +14,9 @@ expectType<number>(Level.TrueColor);
 expectType<boolean>(chalk.supportsColor.hasBasic);
 expectType<boolean>(chalk.supportsColor.has256);
 expectType<boolean>(chalk.supportsColor.has16m);
+
+// - Color -
+expectType<Color>("red");
 
 // - Chalk -
 // -- Instance --


### PR DESCRIPTION
The PR exposes a type for colors supported by chalk. The use case of this is so that consumers of this library can programatically check if a color is available. 

One example is in this PR. https://github.com/facebook/jest/pull/8025

I am hardcoding the possible values that a color can be. https://github.com/facebook/jest/pull/8025/files#diff-6170a10d44dcb3222b64fba6427d69c7R234