### PR TITLE
Improve performance greatly

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -3,22 +3,48 @@
 const chalk = require('.');
 
 suite('chalk', () => {
-	set('iterations', 100000);
+	set('iterations', 1000000);
 
-	bench('single style', () => {
+	const chalkRed = chalk.red;
+	const chalkBgRed = chalk.bgRed;
+	const chalkBlueBgRed = chalk.blue.bgRed;
+	const chalkBlueBgRedBold = chalk.blue.bgRed.bold;
+
+	const blueStyledString = 'the fox jumps' + chalk.blue('over the lazy dog') + '!';
+
+	bench('1 style', () => {
 		chalk.red('the fox jumps over the lazy dog');
 	});
 
-	bench('several styles', () => {
+	bench('2 styles', () => {
+		chalk.blue.bgRed('the fox jumps over the lazy dog');
+	});
+
+	bench('3 styles', () => {
 		chalk.blue.bgRed.bold('the fox jumps over the lazy dog');
 	});
 
-	const cached = chalk.blue.bgRed.bold;
-	bench('cached styles', () => {
-		cached('the fox jumps over the lazy dog');
+	bench('cached: 1 style', () => {
+		chalkRed('the fox jumps over the lazy dog');
 	});
 
-	bench('nested styles', () => {
-		chalk.red('the fox jumps', chalk.underline.bgBlue('over the lazy dog') + '!');
+	bench('cached: 2 styles', () => {
+		chalkBlueBgRed('the fox jumps over the lazy dog');
+	});
+
+	bench('cached: 3 styles', () => {
+		chalkBlueBgRedBold('the fox jumps over the lazy dog');
+	});
+
+	bench('cached: 1 style with newline', () => {
+		chalkRed('the fox jumps\nover the lazy dog');
+	});
+
+	bench('cached: 1 style nested intersecting', () => {
+		chalkRed(blueStyledString);
+	});
+
+	bench('cached: 1 style nested non-intersecting', () => {
+		chalkBgRed(blueStyledString);
 	});
 });

--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -1,6 +1,6 @@
 'use strict';
-const chalk = require('..');
 const styles = require('ansi-styles');
+const chalk = require('..');
 
 // Generates screenshot
 for (const key of Object.keys(styles)) {

--- a/index.js
+++ b/index.js
@@ -193,19 +193,27 @@ const applyStyle = (self, string) => {
 	}
 
 	let styler = self._styler;
-	while (styler !== undefined) {
-		// Replace any instances already present with a re-opening code
-		// otherwise only the part of the string until said closing code
-		// will be colored, and the rest will simply be 'plain'.
-		string = stringReplaceAll(string, styler.close, styler.open);
 
+	if (styler !== undefined) {
+		let closeAll = '';
+		let openAll = '';
+		while (styler !== undefined) {
+			// Replace any instances already present with a re-opening code
+			// otherwise only the part of the string until said closing code
+			// will be colored, and the rest will simply be 'plain'.
+			string = stringReplaceAll(string, styler.close, styler.open);
+
+			openAll = styler.open + openAll;
+			closeAll += styler.close;
+			styler = styler.parent;
+		}
+
+		// We can move both next actions out of loop, because remaining actions in loop won't have any/visible effect on parts we add here
 		// Close the styling before a linebreak and reopen
 		// after next line to fix a bleed issue on macOS
 		// https://github.com/chalk/chalk/pull/92
-		string = stringEncaseCRLF(string, styler.close, styler.open);
-
-		string = styler.open + string + styler.close;
-		styler = styler.parent;
+		string = stringEncaseCRLF(string, closeAll, openAll);
+		string = openAll + string + closeAll;
 	}
 
 	return string;

--- a/index.js
+++ b/index.js
@@ -91,14 +91,18 @@ function Chalk(options) {
 for (const [styleName, style] of Object.entries(ansiStyles)) {
 	styles[styleName] = {
 		get() {
-			return createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty);
+			const builder = createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty);
+			Object.defineProperty(this, styleName, {value: builder});
+			return builder;
 		}
 	};
 }
 
 styles.visible = {
 	get() {
-		return createBuilder(this, this._styler, true);
+		const builder = createBuilder(this, this._styler, true);
+		Object.defineProperty(this, 'visible', {value: builder});
+		return builder;
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const escapeStringRegexp = require('escape-string-regexp');
 const ansiStyles = require('ansi-styles');
 const {stdout: stdoutColor} = require('supports-color');
 const template = require('./templates.js');
@@ -95,8 +94,6 @@ function Chalk(options) {
 }
 
 for (const [styleName, style] of Object.entries(ansiStyles)) {
-	style.closeRe = new RegExp(escapeStringRegexp(style.close), 'g');
-
 	styles[styleName] = {
 		get() {
 			return createBuilder(this, [...(this._styles || []), style], this._isEmpty);
@@ -110,7 +107,6 @@ styles.visible = {
 	}
 };
 
-ansiStyles.color.closeRe = new RegExp(escapeStringRegexp(ansiStyles.color.close), 'g');
 for (const model of Object.keys(ansiStyles.color.ansi)) {
 	if (skipModels.has(model)) {
 		continue;
@@ -123,8 +119,7 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 				const open = ansiStyles.color[levelMapping[level]][model](...arguments_);
 				const codes = {
 					open,
-					close: ansiStyles.color.close,
-					closeRe: ansiStyles.color.closeRe
+					close: ansiStyles.color.close
 				};
 				return createBuilder(this, [...(this._styles || []), codes], this._isEmpty);
 			};
@@ -132,7 +127,6 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 	};
 }
 
-ansiStyles.bgColor.closeRe = new RegExp(escapeStringRegexp(ansiStyles.bgColor.close), 'g');
 for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
 	if (skipModels.has(model)) {
 		continue;
@@ -146,8 +140,7 @@ for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
 				const open = ansiStyles.bgColor[levelMapping[level]][model](...arguments_);
 				const codes = {
 					open,
-					close: ansiStyles.bgColor.close,
-					closeRe: ansiStyles.bgColor.closeRe
+					close: ansiStyles.bgColor.close
 				};
 				return createBuilder(this, [...(this._styles || []), codes], this._isEmpty);
 			};

--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ const createStyler = (open, close, parent) => {
 
 const createBuilder = (self, _styler, _isEmpty) => {
 	const builder = (...arguments_) => {
+		// Single argument is hot path, implicit coercion is faster than anything
 		// eslint-disable-next-line no-implicit-coercion
 		return applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
 	};

--- a/index.js
+++ b/index.js
@@ -178,7 +178,10 @@ const proto = Object.defineProperties(() => {}, {
 });
 
 const createBuilder = (self, _styles, _isEmpty) => {
-	const builder = (...arguments_) => applyStyle(builder, ...arguments_);
+	const builder = (...arguments_) => {
+		// eslint-disable-next-line no-implicit-coercion
+		return applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
+	};
 
 	// `__proto__` is used because we must return a function, but there is
 	// no way to create a function with a different prototype
@@ -191,9 +194,7 @@ const createBuilder = (self, _styles, _isEmpty) => {
 	return builder;
 };
 
-const applyStyle = (self, ...arguments_) => {
-	let string = arguments_.join(' ');
-
+const applyStyle = (self, string) => {
 	if (!self.enabled || self.level <= 0 || !string) {
 		return self._isEmpty ? '' : string;
 	}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ const ansiStyles = require('ansi-styles');
 const {stdout: stdoutColor} = require('supports-color');
 const template = require('./templates.js');
 
+const {
+	stringReplaceAll,
+	stringEncaseCRLFWithFirstIndex
+} = require('./lib/util');
+
 // `supportsColor.level` → `ansiStyles.color[name]` mapping
 const levelMapping = [
 	'ansi',
@@ -10,39 +15,6 @@ const levelMapping = [
 	'ansi256',
 	'ansi16m'
 ];
-
-const stringReplaceAll = (str, substr, replacer) => {
-	let idx = str.indexOf(substr);
-	if (idx === -1) {
-		return str;
-	}
-
-	const subLen = substr.length;
-	let end = 0;
-	let res = '';
-	do {
-		res += str.substr(end, idx - end) + replacer;
-		end = idx + subLen;
-		idx = str.indexOf(substr, end);
-	} while (idx !== -1);
-
-	res += str.substr(end);
-	return res;
-};
-
-const stringEncaseCRLFWithFirstIndex = (str, prefix, postfix, idx) => {
-	let end = 0;
-	let res = '';
-	do {
-		const gotCR = str[idx - 1] === '\r';
-		res += str.substr(end, (gotCR ? idx - 1 : idx) - end) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
-		end = idx + 1;
-		idx = str.indexOf('\n', end);
-	} while (idx !== -1);
-
-	res += str.substr(end);
-	return res;
-};
 
 // `color-convert` models to exclude from the Chalk API due to conflicts and such
 const skipModels = new Set(['gray']);
@@ -226,9 +198,9 @@ const applyStyle = (self, string) => {
 	// Close the styling before a linebreak and reopen
 	// after next line to fix a bleed issue on macOS
 	// https://github.com/chalk/chalk/pull/92
-	const lfIdx = string.indexOf('\n');
-	if (lfIdx !== -1) {
-		string = stringEncaseCRLFWithFirstIndex(string, closeAll, openAll, lfIdx);
+	const lfIndex = string.indexOf('\n');
+	if (lfIndex !== -1) {
+		string = stringEncaseCRLFWithFirstIndex(string, closeAll, openAll, lfIndex);
 	}
 
 	return openAll + string + closeAll;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,37 @@
+const stringReplaceAll = (string, substring, replacer) => {
+	let index = string.indexOf(substring);
+	if (index === -1) {
+		return string;
+	}
+
+	const subLen = substring.length;
+	let end = 0;
+	let res = '';
+	do {
+		res += string.substr(end, index - end) + replacer;
+		end = index + subLen;
+		index = string.indexOf(substring, end);
+	} while (index !== -1);
+
+	res += string.substr(end);
+	return res;
+};
+
+const stringEncaseCRLFWithFirstIndex = (string, prefix, postfix, index) => {
+	let end = 0;
+	let res = '';
+	do {
+		const gotCR = string[index - 1] === '\r';
+		res += string.substr(end, (gotCR ? index - 1 : index) - end) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
+		end = index + 1;
+		index = string.indexOf('\n', end);
+	} while (index !== -1);
+
+	res += string.substr(end);
+	return res;
+};
+
+module.exports = {
+	stringReplaceAll,
+	stringEncaseCRLFWithFirstIndex
+};

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.1",
-		"escape-string-regexp": "^1.0.5",
 		"supports-color": "^6.1.0"
 	},
 	"devDependencies": {

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -82,6 +82,10 @@ test('line breaks should open and close colors', t => {
 	t.is(chalk.grey('hello\nworld'), '\u001B[90mhello\u001B[39m\n\u001B[90mworld\u001B[39m');
 });
 
+test('line breaks should open and close colors with CRLF', t => {
+	t.is(chalk.grey('hello\r\nworld'), '\u001B[90mhello\u001B[39m\r\n\u001B[90mworld\u001B[39m');
+});
+
 test('properly convert RGB to 16 colors on basic color terminals', t => {
 	t.is(new chalk.Instance({level: 1}).hex('#FF0000')('hello'), '\u001B[91mhello\u001B[39m');
 	t.is(new chalk.Instance({level: 1}).bgHex('#FF0000')('hello'), '\u001B[101mhello\u001B[49m');


### PR DESCRIPTION
Fixes #333 

Benchmark:
  - updated to reflect essential use cases and performance eaters
  - NOTE: benchmark framework reports incorrect high number for first bench on some runs, reason unknown

Based on my own usage of chalk, I select KPM:
  - `cached`: average of `cached: 1 style` and `cached: 2 styles` metrics
  - `non-cached`: average of `1 style` and `2 styles` metrics
  - `total`: average of all metrics

KPM increase:
  - `cached`: x23
  - `non-cached`: x129
  - `total`: x24

Changes(incrementally increasing preformance):
  - replaced regexp replaces by indexOf-slice implementation
  - streamlined builder instantiation
  - moved argument handling out of hot zone and optimized
  - removed all regexp stuff and escape-string-regexp dependency
  - replaced arrays by linked lists
  - precomputed chains of open/close codes
  - close code replace not applied to codes inserted around CRLF, it can change output in some cases, but doesnt change effective styles
  - added fastpath for do no close code replaces if there is no escape sequences in source string
  - cached simple getters results(in getters `this`)

Original(with new benchmark) metrics:
```
         269,472 op/s » 1 style
         130,959 op/s » 2 styles
          86,590 op/s » 3 styles
       1,407,114 op/s » cached: 1 style
         749,141 op/s » cached: 2 styles
         502,693 op/s » cached: 3 styles
       1,245,477 op/s » cached: 1 style with newline
       1,386,202 op/s » cached: 1 style nested intersecting
       1,368,144 op/s » cached: 1 style nested non-intersecting
```
Original KPM:
  - `cached`: 1078 kop/s
  - `non-cached`: 200 kop/s
  - `total`: 794 kop/s

Result metrics:
```
      29,685,124 op/s » 1 style
      21,955,435 op/s » 2 styles
      18,687,591 op/s » 3 styles
      26,847,185 op/s » cached: 1 style
      23,004,420 op/s » cached: 2 styles
      18,772,011 op/s » cached: 3 styles
      12,552,691 op/s » cached: 1 style with newline
       5,585,706 op/s » cached: 1 style nested intersecting
      15,220,157 op/s » cached: 1 style nested non-intersecting
```
Result KPM:
  - `cached:` 24925 kop/s
  - `non-cached`: 25820 kop/s
  - `total`: 19145 kop/s
