### PR TITLE
Fix TypeScript types for `supportsColor` which is top‑level only

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,11 +70,25 @@ declare namespace chalk {
 		has16m: boolean;
 	}
 
-	type ChalkTemplateFunction = (text: TemplateStringsArray, ...placeholders: unknown[]) => string;
+	interface ChalkFunction {
+		/**
+		Use a template string.
 
-	interface Chalk {
+		@remarks Template literals are unsupported for nested calls (see [issue #341](https://github.com/chalk/chalk/issues/341))
+
+		@example
+		log(chalk`
+		CPU: {red ${cpu.totalPercent}%}
+		RAM: {green ${ram.used / ram.total * 100}%}
+		DISK: {rgb(255,131,0) ${disk.used / disk.total * 100}%}
+		`);
+		*/
+		(text: TemplateStringsArray, ...placeholders: unknown[]): string;
+
 		(...text: unknown[]): string;
+	}
 
+	interface Chalk extends ChalkFunction {
 		/**
 		Return a new Chalk instance.
 		*/
@@ -273,7 +287,7 @@ Call the last one as a method with a string argument.
 Order doesn't matter, and later styles take precedent in case of a conflict.
 This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
-declare const chalk: NoThis<chalk.Chalk> & chalk.ChalkTemplateFunction & {
+declare const chalk: NoThis<chalk.Chalk> & chalk.ChalkFunction & {
 	supportsColor: chalk.ColorSupport;
 	Level: typeof LevelEnum;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,11 +77,13 @@ declare namespace chalk {
 		@remarks Template literals are unsupported for nested calls (see [issue #341](https://github.com/chalk/chalk/issues/341))
 
 		@example
+		```
 		log(chalk`
 		CPU: {red ${cpu.totalPercent}%}
 		RAM: {green ${ram.used / ram.total * 100}%}
 		DISK: {rgb(255,131,0) ${disk.used / disk.total * 100}%}
 		`);
+		```
 		*/
 		(text: TemplateStringsArray, ...placeholders: unknown[]): string;
 
@@ -113,9 +115,11 @@ declare namespace chalk {
 		@param color - Hexadecimal value representing the desired color.
 
 		@example
+		```
 		import chalk = require('chalk');
 
 		chalk.hex('#DEADED');
+		```
 		*/
 		hex(color: string): Chalk;
 
@@ -125,9 +129,11 @@ declare namespace chalk {
 		@param color - Keyword value representing the desired color.
 
 		@example
+		```
 		import chalk = require('chalk');
 
 		chalk.keyword('orange');
+		```
 		*/
 		keyword(color: string): Chalk;
 
@@ -157,9 +163,11 @@ declare namespace chalk {
 		@param color - Hexadecimal value representing the desired color.
 
 		@example
+		```
 		import chalk = require('chalk');
 
 		chalk.bgHex('#DEADED');
+		```
 		*/
 		bgHex(color: string): Chalk;
 
@@ -169,9 +177,11 @@ declare namespace chalk {
 		@param color - Keyword value representing the desired color.
 
 		@example
+		```
 		import chalk = require('chalk');
 
 		chalk.bgKeyword('orange');
+		```
 		*/
 		bgKeyword(color: string): Chalk;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,10 +70,10 @@ declare namespace chalk {
 		has16m: boolean;
 	}
 
+	type ChalkTemplateFunction = (text: TemplateStringsArray, ...placeholders: unknown[]) => string;
+
 	interface Chalk {
 		(...text: unknown[]): string;
-
-		(text: TemplateStringsArray, ...placeholders: unknown[]): string;
 
 		/**
 		Return a new Chalk instance.
@@ -99,11 +99,9 @@ declare namespace chalk {
 		@param color - Hexadecimal value representing the desired color.
 
 		@example
-		```
 		import chalk = require('chalk');
 
 		chalk.hex('#DEADED');
-		```
 		*/
 		hex(color: string): this;
 
@@ -113,11 +111,9 @@ declare namespace chalk {
 		@param color - Keyword value representing the desired color.
 
 		@example
-		```
 		import chalk = require('chalk');
 
 		chalk.keyword('orange');
-		```
 		*/
 		keyword(color: string): this;
 
@@ -147,11 +143,9 @@ declare namespace chalk {
 		@param color - Hexadecimal value representing the desired color.
 
 		@example
-		```
 		import chalk = require('chalk');
 
 		chalk.bgHex('#DEADED');
-		```
 		*/
 		bgHex(color: string): this;
 
@@ -161,11 +155,9 @@ declare namespace chalk {
 		@param color - Keyword value representing the desired color.
 
 		@example
-		```
 		import chalk = require('chalk');
 
 		chalk.bgKeyword('orange');
-		```
 		*/
 		bgKeyword(color: string): this;
 
@@ -273,13 +265,15 @@ declare namespace chalk {
 	}
 }
 
+declare type NoThis<T> = {[K in keyof T]: T[K] extends T ? T : T[K]};
+
 /**
 Main Chalk object that allows to chain styles together.
 Call the last one as a method with a string argument.
 Order doesn't matter, and later styles take precedent in case of a conflict.
 This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
-declare const chalk: chalk.Chalk & {
+declare const chalk: NoThis<chalk.Chalk> & chalk.ChalkTemplateFunction & {
 	supportsColor: chalk.ColorSupport;
 	Level: typeof LevelEnum;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,7 +117,7 @@ declare namespace chalk {
 
 		chalk.hex('#DEADED');
 		*/
-		hex(color: string): this;
+		hex(color: string): Chalk;
 
 		/**
 		Use keyword color value to set text color.
@@ -129,27 +129,27 @@ declare namespace chalk {
 
 		chalk.keyword('orange');
 		*/
-		keyword(color: string): this;
+		keyword(color: string): Chalk;
 
 		/**
 		Use RGB values to set text color.
 		*/
-		rgb(red: number, green: number, blue: number): this;
+		rgb(red: number, green: number, blue: number): Chalk;
 
 		/**
 		Use HSL values to set text color.
 		*/
-		hsl(hue: number, saturation: number, lightness: number): this;
+		hsl(hue: number, saturation: number, lightness: number): Chalk;
 
 		/**
 		Use HSV values to set text color.
 		*/
-		hsv(hue: number, saturation: number, value: number): this;
+		hsv(hue: number, saturation: number, value: number): Chalk;
 
 		/**
 		Use HWB values to set text color.
 		*/
-		hwb(hue: number, whiteness: number, blackness: number): this;
+		hwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
 		Use HEX value to set background color.
@@ -161,7 +161,7 @@ declare namespace chalk {
 
 		chalk.bgHex('#DEADED');
 		*/
-		bgHex(color: string): this;
+		bgHex(color: string): Chalk;
 
 		/**
 		Use keyword color value to set background color.
@@ -173,113 +173,111 @@ declare namespace chalk {
 
 		chalk.bgKeyword('orange');
 		*/
-		bgKeyword(color: string): this;
+		bgKeyword(color: string): Chalk;
 
 		/**
 		Use RGB values to set background color.
 		*/
-		bgRgb(red: number, green: number, blue: number): this;
+		bgRgb(red: number, green: number, blue: number): Chalk;
 
 		/**
 		Use HSL values to set background color.
 		*/
-		bgHsl(hue: number, saturation: number, lightness: number): this;
+		bgHsl(hue: number, saturation: number, lightness: number): Chalk;
 
 		/**
 		Use HSV values to set background color.
 		*/
-		bgHsv(hue: number, saturation: number, value: number): this;
+		bgHsv(hue: number, saturation: number, value: number): Chalk;
 
 		/**
 		Use HWB values to set background color.
 		*/
-		bgHwb(hue: number, whiteness: number, blackness: number): this;
+		bgHwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
 		Modifier: Resets the current color chain.
 		*/
-		readonly reset: this;
+		readonly reset: Chalk;
 
 		/**
 		Modifier: Make text bold.
 		*/
-		readonly bold: this;
+		readonly bold: Chalk;
 
 		/**
 		Modifier: Emitting only a small amount of light.
 		*/
-		readonly dim: this;
+		readonly dim: Chalk;
 
 		/**
 		Modifier: Make text italic. (Not widely supported)
 		*/
-		readonly italic: this;
+		readonly italic: Chalk;
 
 		/**
 		Modifier: Make text underline. (Not widely supported)
 		*/
-		readonly underline: this;
+		readonly underline: Chalk;
 
 		/**
 		Modifier: Inverse background and foreground colors.
 		*/
-		readonly inverse: this;
+		readonly inverse: Chalk;
 
 		/**
 		Modifier: Prints the text, but makes it invisible.
 		*/
-		readonly hidden: this;
+		readonly hidden: Chalk;
 
 		/**
 		Modifier: Puts a horizontal line through the center of the text. (Not widely supported)
 		*/
-		readonly strikethrough: this;
+		readonly strikethrough: Chalk;
 
 		/**
 		Modifier: Prints the text only when Chalk is enabled.
 		Can be useful for things that are purely cosmetic.
 		*/
-		readonly visible: this;
+		readonly visible: Chalk;
 
-		readonly black: this;
-		readonly red: this;
-		readonly green: this;
-		readonly yellow: this;
-		readonly blue: this;
-		readonly magenta: this;
-		readonly cyan: this;
-		readonly white: this;
-		readonly gray: this;
-		readonly grey: this;
-		readonly blackBright: this;
-		readonly redBright: this;
-		readonly greenBright: this;
-		readonly yellowBright: this;
-		readonly blueBright: this;
-		readonly magentaBright: this;
-		readonly cyanBright: this;
-		readonly whiteBright: this;
+		readonly black: Chalk;
+		readonly red: Chalk;
+		readonly green: Chalk;
+		readonly yellow: Chalk;
+		readonly blue: Chalk;
+		readonly magenta: Chalk;
+		readonly cyan: Chalk;
+		readonly white: Chalk;
+		readonly gray: Chalk;
+		readonly grey: Chalk;
+		readonly blackBright: Chalk;
+		readonly redBright: Chalk;
+		readonly greenBright: Chalk;
+		readonly yellowBright: Chalk;
+		readonly blueBright: Chalk;
+		readonly magentaBright: Chalk;
+		readonly cyanBright: Chalk;
+		readonly whiteBright: Chalk;
 
-		readonly bgBlack: this;
-		readonly bgRed: this;
-		readonly bgGreen: this;
-		readonly bgYellow: this;
-		readonly bgBlue: this;
-		readonly bgMagenta: this;
-		readonly bgCyan: this;
-		readonly bgWhite: this;
-		readonly bgBlackBright: this;
-		readonly bgRedBright: this;
-		readonly bgGreenBright: this;
-		readonly bgYellowBright: this;
-		readonly bgBlueBright: this;
-		readonly bgMagentaBright: this;
-		readonly bgCyanBright: this;
-		readonly bgWhiteBright: this;
+		readonly bgBlack: Chalk;
+		readonly bgRed: Chalk;
+		readonly bgGreen: Chalk;
+		readonly bgYellow: Chalk;
+		readonly bgBlue: Chalk;
+		readonly bgMagenta: Chalk;
+		readonly bgCyan: Chalk;
+		readonly bgWhite: Chalk;
+		readonly bgBlackBright: Chalk;
+		readonly bgRedBright: Chalk;
+		readonly bgGreenBright: Chalk;
+		readonly bgYellowBright: Chalk;
+		readonly bgBlueBright: Chalk;
+		readonly bgMagentaBright: Chalk;
+		readonly bgCyanBright: Chalk;
+		readonly bgWhiteBright: Chalk;
 	}
 }
-
-declare type NoThis<T> = {[K in keyof T]: T[K] extends T ? T : T[K]};
 
 /**
 Main Chalk object that allows to chain styles together.
@@ -287,7 +285,7 @@ Call the last one as a method with a string argument.
 Order doesn't matter, and later styles take precedent in case of a conflict.
 This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
-declare const chalk: NoThis<chalk.Chalk> & chalk.ChalkFunction & {
+declare const chalk: chalk.Chalk & chalk.ChalkFunction & {
 	supportsColor: chalk.ColorSupport;
 	Level: typeof LevelEnum;
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectError} from 'tsd';
 import chalk = require('.');
 
 // - Helpers -
@@ -14,6 +14,9 @@ expectType<number>(chalk.Level.TrueColor);
 expectType<boolean>(chalk.supportsColor.hasBasic);
 expectType<boolean>(chalk.supportsColor.has256);
 expectType<boolean>(chalk.supportsColor.has16m);
+
+// -- `supportsColor` is not a member of the Chalk interface --
+expectError(chalk.reset.supportsColor);
 
 // - Chalk -
 // -- Instance --

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,7 +2,7 @@ import {expectType} from 'tsd';
 import chalk = require('.');
 
 // - Helpers -
-type colorReturn = chalk.Chalk & {supportsColor: chalk.ColorSupport};
+type colorReturn = chalk.Chalk & {supportsColor?: never};
 
 // - Level -
 expectType<number>(chalk.Level.None);


### PR DESCRIPTION
The `supportsColor` property only exists on the top level:
```js
chalk.supportsColor; // object
chalk.bold.supportsColor; // undefined

'supportsColor' in chalk; // true
'supportsColor' in chalk.bold; // false
```

review?(@BendingBender, @Qix-, @sindresorhus)