### PR TITLE
fix: Add Babel compatible `__esModule` export

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,6 +197,9 @@ const chalkTag = (chalk, ...strings) => {
 
 Object.defineProperties(Chalk.prototype, styles);
 
-module.exports = Chalk(); // eslint-disable-line new-cap
-module.exports.supportsColor = stdoutColor;
-module.exports.default = module.exports; // For TypeScript
+exports = module.exports = Chalk(); // eslint-disable-line new-cap, no-multi-assign
+exports.supportsColor = stdoutColor;
+
+// For TypeScript and Babel:
+exports.default = module.exports;
+Object.defineProperty(exports, '__esModule', {value: true});


### PR DESCRIPTION
Since this module now supports the `default` export, it makes sense to add the Babel compatible `__esModule` export.

## See also:
- https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs