### PR TITLE
Add missing `false` type to chalk.supportsColor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -296,7 +296,7 @@ Order doesn't matter, and later styles take precedent in case of a conflict.
 This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
 declare const chalk: chalk.Chalk & chalk.ChalkFunction & {
-	supportsColor: chalk.ColorSupport;
+	supportsColor: chalk.ColorSupport | false;
 	Level: typeof LevelEnum;
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,9 +11,10 @@ expectType<number>(chalk.Level.Ansi256);
 expectType<number>(chalk.Level.TrueColor);
 
 // - supportsColor -
-expectType<boolean>(chalk.supportsColor.hasBasic);
-expectType<boolean>(chalk.supportsColor.has256);
-expectType<boolean>(chalk.supportsColor.has16m);
+expectType<chalk.ColorSupport | false>(chalk.supportsColor);
+expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).hasBasic);
+expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).has256);
+expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).has16m);
 
 // -- `supportsColor` is not a member of the Chalk interface --
 expectError(chalk.reset.supportsColor);


### PR DESCRIPTION
`chalk.supportsColor` is not obliged to return a `chalk.ColorSupport` object but may as well [return `false`](https://github.com/chalk/supports-color/blob/4f9558ef6e173672f659494c57dfa306fb8d5692/index.js#L32) which is not currently reflected in the type definitions.

This PR fixes that, adds a fitting test and adjusts existing tests accordingly.