### PR TITLE
Remove outdated info in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,7 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 - `red`
 - `green`
 - `yellow`
-- `blue` *(On Windows the bright version is used since normal blue is illegible)*
+- `blue`
 - `magenta`
 - `cyan`
 - `white`


### PR DESCRIPTION
Since #330 was merged, the blue workaround for windows no longer exists, so let's remove an indication about that on the README.