### PR TITLE
Improve require speed

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const ansiStyles = require('ansi-styles');
 const {stdout: stdoutColor, stderr: stderrColor} = require('supports-color');
-const template = require('./templates');
 const {
 	stringReplaceAll,
 	stringEncaseCRLFWithFirstIndex
@@ -185,6 +184,7 @@ const applyStyle = (self, string) => {
 	return openAll + string + closeAll;
 };
 
+let template;
 const chalkTag = (chalk, ...strings) => {
 	const [firstString] = strings;
 
@@ -204,6 +204,9 @@ const chalkTag = (chalk, ...strings) => {
 		);
 	}
 
+	if (template === undefined) {
+		template = require('./templates');
+	}
 	return template(chalk, parts.join(''));
 };
 

--- a/source/index.js
+++ b/source/index.js
@@ -72,7 +72,7 @@ styles.visible = {
 	}
 };
 
-const usedModels = ['rgb', 'hsl', 'hsv', 'hwb', 'cmyk', 'xyz', 'lab', 'lch', 'hex', 'keyword', 'ansi', 'ansi256', 'hcg', 'apple'];
+const usedModels = ['rgb', 'hex', 'keyword', 'hsl', 'hsv', 'hwb', 'ansi', 'ansi256'];
 
 for (const model of usedModels) {
 	styles[model] = {

--- a/source/index.js
+++ b/source/index.js
@@ -72,9 +72,9 @@ styles.visible = {
 	}
 };
 
-const useModels = ['rgb', 'hsl', 'hsv', 'hwb', 'cmyk', 'xyz', 'lab', 'lch', 'hex', 'keyword', 'ansi', 'ansi256', 'hcg', 'apple'];
+const usedModels = ['rgb', 'hsl', 'hsv', 'hwb', 'cmyk', 'xyz', 'lab', 'lch', 'hex', 'keyword', 'ansi', 'ansi256', 'hcg', 'apple'];
 
-for (const model of useModels) {
+for (const model of usedModels) {
 	styles[model] = {
 		get() {
 			const {level} = this;
@@ -86,7 +86,7 @@ for (const model of useModels) {
 	};
 }
 
-for (const model of useModels) {
+for (const model of usedModels) {
 	const bgModel = 'bg' + model[0].toUpperCase() + model.slice(1);
 	styles[bgModel] = {
 		get() {
@@ -207,6 +207,7 @@ const chalkTag = (chalk, ...strings) => {
 	if (template === undefined) {
 		template = require('./templates');
 	}
+
 	return template(chalk, parts.join(''));
 };
 

--- a/source/index.js
+++ b/source/index.js
@@ -15,9 +15,6 @@ const levelMapping = [
 	'ansi16m'
 ];
 
-// `color-convert` models to exclude from the Chalk API due to conflicts and such
-const skipModels = new Set(['gray']);
-
 const styles = Object.create(null);
 
 const applyOptions = (object, options = {}) => {
@@ -76,11 +73,9 @@ styles.visible = {
 	}
 };
 
-for (const model of Object.keys(ansiStyles.color.ansi)) {
-	if (skipModels.has(model)) {
-		continue;
-	}
+const useModels = ['rgb', 'hsl', 'hsv', 'hwb', 'cmyk', 'xyz', 'lab', 'lch', 'hex', 'keyword', 'ansi', 'ansi256', 'hcg', 'apple'];
 
+for (const model of useModels) {
 	styles[model] = {
 		get() {
 			const {level} = this;
@@ -92,11 +87,7 @@ for (const model of Object.keys(ansiStyles.color.ansi)) {
 	};
 }
 
-for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
-	if (skipModels.has(model)) {
-		continue;
-	}
-
+for (const model of useModels) {
 	const bgModel = 'bg' + model[0].toUpperCase() + model.slice(1);
 	styles[bgModel] = {
 		get() {


### PR DESCRIPTION
- Lazy load templates(runtime overhead should be zero due to prototype check overlapping with `=== undefined` check)
 - Don't access `ansi-styles` color space converters unless needed

This patch works in conjunction with(but works without them too, though to much smaller effect):
 - https://github.com/chalk/ansi-styles/pull/53
 - https://github.com/chalk/supports-color/pull/101

Require speed test results before:
![before](https://user-images.githubusercontent.com/176214/61600033-16f75f00-ac37-11e9-8635-bb178a266fcf.png)

Require speed test results after(pure require, without using template nor color conversion functionality):
![after](https://user-images.githubusercontent.com/176214/61600036-1959b900-ac37-11e9-9dff-27554ca2a899.png)

Note: in both cases, a huge part of time is spent initializing `tty`(or initializing `process.stdout` and `process.stderr`, which includes initializing `tty`), which is also triggered by a lot of other parts of stdlib(for example by `console.log` with non-string arguments), and is required in order to detect if output supports color, so is expected to be initialized anyway by a lot of real life programs(notable exception: programs which conditionally produce no output). If we subtract the time required for this initializations, the final numbers will be ~10ms and ~5ms, respectively.

Fixes #180


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#180: Improve require speed](https://issuehunt.io/repos/11855195/issues/180)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->