### PR TITLE
Add `chalk.stderr`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -378,6 +378,7 @@ declare const chalk: chalk.Chalk & chalk.ChalkFunction & {
 	ForegroundColor: ForegroundColor;
 	BackgroundColor: BackgroundColor;
 	Modifiers: Modifiers;
+	stderr: chalk.Chalk & {supportsColor: chalk.ColorSupport | false};
 };
 
 export = chalk;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,6 +16,16 @@ expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).hasBasic);
 expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).has256);
 expectType<boolean>((chalk.supportsColor as chalk.ColorSupport).has16m);
 
+// - stderr -
+expectType<chalk.Chalk>(chalk.stderr);
+expectType<chalk.ColorSupport | false>(chalk.stderr.supportsColor);
+expectType<boolean>((chalk.stderr.supportsColor as chalk.ColorSupport).hasBasic);
+expectType<boolean>((chalk.stderr.supportsColor as chalk.ColorSupport).has256);
+expectType<boolean>((chalk.stderr.supportsColor as chalk.ColorSupport).has16m);
+
+// -- `stderr` is not a member of the Chalk interface --
+expectError(chalk.reset.stderr);
+
 // -- `supportsColor` is not a member of the Chalk interface --
 expectError(chalk.reset.supportsColor);
 

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,11 @@ Can be overridden by the user with the flags `--color` and `--no-color`. For sit
 
 Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 
+### chalk.stderr and chalk.stderr.supportsColor
+
+`chalk.stderr` contains a separate instance configured with color support detected for `stderr` stream instead of `stdout`.
+Override rules from `chalk.supportsColor` apply to this too.
+`chalk.stderr.supportsColor` is exposed for convinience.
 
 ## Styles
 

--- a/readme.md
+++ b/readme.md
@@ -149,9 +149,8 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 
 ### chalk.stderr and chalk.stderr.supportsColor
 
-`chalk.stderr` contains a separate instance configured with color support detected for `stderr` stream instead of `stdout`.
-Override rules from `chalk.supportsColor` apply to this too.
-`chalk.stderr.supportsColor` is exposed for convenience.
+`chalk.stderr` contains a separate instance configured with color support detected for `stderr` stream instead of `stdout`. Override rules from `chalk.supportsColor` apply to this too. `chalk.stderr.supportsColor` is exposed for convenience.
+
 
 ## Styles
 

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=
 
 `chalk.stderr` contains a separate instance configured with color support detected for `stderr` stream instead of `stdout`.
 Override rules from `chalk.supportsColor` apply to this too.
-`chalk.stderr.supportsColor` is exposed for convinience.
+`chalk.stderr.supportsColor` is exposed for convenience.
 
 ## Styles
 

--- a/source/index.js
+++ b/source/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const ansiStyles = require('ansi-styles');
-const {stdout: stdoutColor} = require('supports-color');
+const {stdout: stdoutColor, stderr: stderrColor} = require('supports-color');
 const template = require('./templates');
 const {
 	stringReplaceAll,
@@ -218,5 +218,9 @@ const chalkTag = (chalk, ...strings) => {
 
 Object.defineProperties(Chalk.prototype, styles);
 
-module.exports = Chalk(); // eslint-disable-line new-cap
-module.exports.supportsColor = stdoutColor;
+const chalk = Chalk(); // eslint-disable-line new-cap
+chalk.supportsColor = stdoutColor;
+chalk.stderr = Chalk({level: stderrColor ? stderrColor.level : 0}); // eslint-disable-line new-cap
+chalk.stderr.supportsColor = stderrColor;
+
+module.exports = chalk;

--- a/test/_fixture.js
+++ b/test/_fixture.js
@@ -1,4 +1,4 @@
 'use strict';
 const chalk = require('../source');
 
-console.log(chalk.hex('#ff6159')('test'));
+console.log(`${chalk.hex('#ff6159')('testout')} ${chalk.stderr.hex('#ff6159')('testerr')}`);

--- a/test/_supports-color.js
+++ b/test/_supports-color.js
@@ -7,6 +7,12 @@ const DEFAULT = {
 		hasBasic: true,
 		has256: true,
 		has16m: true
+	},
+	stderr: {
+		level: 3,
+		hasBasic: true,
+		has256: true,
+		has16m: true
 	}
 };
 

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -105,3 +105,7 @@ test('don\'t emit RGB codes if level is 0', t => {
 test('supports blackBright color', t => {
 	t.is(chalk.blackBright('foo'), '\u001B[90mfoo\u001B[39m');
 });
+
+test('sets correct level for chalk.stderr', t => {
+	t.is(chalk.stderr.level, 3);
+});

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -106,6 +106,7 @@ test('supports blackBright color', t => {
 	t.is(chalk.blackBright('foo'), '\u001B[90mfoo\u001B[39m');
 });
 
-test('sets correct level for chalk.stderr', t => {
+test('sets correct level for chalk.stderr and respects it', t => {
 	t.is(chalk.stderr.level, 3);
+	t.is(chalk.stderr.red.bold('foo'), '\u001B[31m\u001B[1mfoo\u001B[22m\u001B[39m');
 });

--- a/test/level.js
+++ b/test/level.js
@@ -41,5 +41,5 @@ test('propagate enable/disable changes from child colors', t => {
 
 test('disable colors if they are not supported', async t => {
 	const {stdout} = await execa.node(path.join(__dirname, '_fixture'));
-	t.is(stdout, 'test');
+	t.is(stdout, 'testout testerr');
 });

--- a/test/no-color-support.js
+++ b/test/no-color-support.js
@@ -2,10 +2,18 @@ import test from 'ava';
 
 // Spoof supports-color
 require('./_supports-color')(__dirname, {
-	level: 0,
-	hasBasic: false,
-	has256: false,
-	has16m: false
+	stdout: {
+		level: 0,
+		hasBasic: false,
+		has256: false,
+		has16m: false
+	},
+	stderr: {
+		level: 0,
+		hasBasic: false,
+		has256: false,
+		has16m: false
+	}
 });
 
 const chalk = require('../source');


### PR DESCRIPTION
Subj.

Fixes #301

Also, fixes incorrect test setup in `test/no-color-support.js`.

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#301: Auto-detect support for `stderr`](https://issuehunt.io/repos/11855195/issues/301)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->