### PR TITLE
Replace level list with table in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,12 +132,12 @@ If you need to change this in a reusable module, create a new instance:
 const ctx = new chalk.Instance({level: 0});
 ```
 
-Levels are as follows:
-
-0. All colors disabled
-1. Basic color support (16 colors)
-2. 256 color support
-3. Truecolor support (16 million colors)
+| level | description |
+| ---: | :--- |
+| `0` | All colors disabled |
+| `1` | Basic color support (16 colors) |
+| `2` | 256 color support |
+| `3` | Truecolor support (16 million colors) |
 
 ### chalk.supportsColor
 

--- a/readme.md
+++ b/readme.md
@@ -132,8 +132,8 @@ If you need to change this in a reusable module, create a new instance:
 const ctx = new chalk.Instance({level: 0});
 ```
 
-| level | description |
-| ---: | :--- |
+| Level | Description |
+| :---: | :--- |
 | `0` | All colors disabled |
 | `1` | Basic color support (16 colors) |
 | `2` | 256 color support |


### PR DESCRIPTION
First of all, thank you for this excellent package <3

To use 256 background colors when available, I tripped over 0-based versus 1-based `level`

Although `readme.md` has 0-based numbered list, here is picture of the **list** on `npm` page:

<img width="730" alt="chalk-level-list" src="https://user-images.githubusercontent.com/11862657/65911534-ca4ca480-e39a-11e9-962f-55773e97a549.png">

Here is picture of the proposed **table** in markdown preview of code editor:

<img width="346" alt="chalk-level-table" src="https://user-images.githubusercontent.com/11862657/65911514-c4ef5a00-e39a-11e9-8b09-f3d867b18234.png">

Updated picture according to **review** comments:

<img width="352" alt="chalk-level-table-2" src="https://user-images.githubusercontent.com/11862657/65915449-7c876a80-e3a1-11e9-8027-3ac03ce0119b.png">