### PR TITLE
Add `ansi256` and `bgAnsi256` to TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -214,7 +214,7 @@ declare namespace chalk {
 		hwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
-		Use 8-bit unsigned number to set text color.
+		Use a [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set text color.
 		*/
 		ansi256(index: number): Chalk;
 
@@ -267,7 +267,7 @@ declare namespace chalk {
 		bgHwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
-		Use 8-bit unsigned number to set background color.
+		Use a [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set background color.
 		*/
 		bgAnsi256(index: number): Chalk;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -214,7 +214,7 @@ declare namespace chalk {
 		hwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
-		Use 8-bit unsigned numbers to set text color.
+		Use 8-bit unsigned number to set text color.
 		*/
 		ansi256(index: number): Chalk;
 
@@ -267,7 +267,7 @@ declare namespace chalk {
 		bgHwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
-		Use 8-bit unsigned numbers to set background color.
+		Use 8-bit unsigned number to set background color.
 		*/
 		bgAnsi256(index: number): Chalk;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -214,6 +214,11 @@ declare namespace chalk {
 		hwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
+		Use 8-bit unsigned numbers to set text color.
+		*/
+		ansi256(index: number): Chalk;
+
+		/**
 		Use HEX value to set background color.
 
 		@param color - Hexadecimal value representing the desired color.
@@ -260,6 +265,11 @@ declare namespace chalk {
 		Use HWB values to set background color.
 		*/
 		bgHwb(hue: number, whiteness: number, blackness: number): Chalk;
+
+		/**
+		Use 8-bit unsigned numbers to set background color.
+		*/
+		bgAnsi256(index: number): Chalk;
 
 		/**
 		Modifier: Resets the current color chain.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -49,12 +49,14 @@ expectType<colorReturn>(chalk.rgb(0, 0, 0));
 expectType<colorReturn>(chalk.hsl(0, 0, 0));
 expectType<colorReturn>(chalk.hsv(0, 0, 0));
 expectType<colorReturn>(chalk.hwb(0, 0, 0));
+expectType<colorReturn>(chalk.ansi256(0));
 expectType<colorReturn>(chalk.bgHex('#DEADED'));
 expectType<colorReturn>(chalk.bgKeyword('orange'));
 expectType<colorReturn>(chalk.bgRgb(0, 0, 0));
 expectType<colorReturn>(chalk.bgHsl(0, 0, 0));
 expectType<colorReturn>(chalk.bgHsv(0, 0, 0));
 expectType<colorReturn>(chalk.bgHwb(0, 0, 0));
+expectType<colorReturn>(chalk.bgAnsi256(0));
 
 // -- Modifiers --
 expectType<string>(chalk.reset('foo'));

--- a/readme.md
+++ b/readme.md
@@ -260,9 +260,9 @@ The following color models can be used:
 - [`keyword`](https://www.w3.org/wiki/CSS/Properties/color/keywords) (CSS keywords) - Example: `chalk.keyword('orange').bold('Orange!')`
 - [`hsl`](https://en.wikipedia.org/wiki/HSL_and_HSV) - Example: `chalk.hsl(32, 100, 50).bold('Orange!')`
 - [`hsv`](https://en.wikipedia.org/wiki/HSL_and_HSV) - Example: `chalk.hsv(32, 100, 100).bold('Orange!')`
-- [`hwb`](https://en.wikipedia.org/wiki/HWB_color_model)  - Example: `chalk.hwb(32, 0, 50).bold('Orange!')`
+- [`hwb`](https://en.wikipedia.org/wiki/HWB_color_model) - Example: `chalk.hwb(32, 0, 50).bold('Orange!')`
 - `ansi16`
-- `ansi256`
+- [`ansi256`](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) - Example: `chalk.bgAnsi256(194)('Honeydew, more or less')`
 
 
 ## Windows


### PR DESCRIPTION
When I test `bgAnsi256` as visual enhancement,  `2.4.2` and `3.0.0-beta.1` have TypeScript errors:

```text
ansi256.ts:3:30 - error TS2339: Property 'bgAnsi256' does not exist on type 'Chalk'.

3 const aColor = chalk.magenta.bgAnsi256(225);
                               ~~~~~~~~~

ansi256.ts:4:28 - error TS2339: Property 'bgAnsi256' does not exist on type 'Chalk'.

4 const bColor = chalk.green.bgAnsi256(194);
```

1. Add 2 type tests to `index.test-d.ts` which failed first
2. Add 2 declarations to `index.d.ts`
3. Add link and example to `readme.md`
4. Delete extra space in neighbor line of `readme.md`