### PR TITLE
Add `ansi` and `bgAnsi` to TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -214,6 +214,14 @@ declare namespace chalk {
 		hwb(hue: number, whiteness: number, blackness: number): Chalk;
 
 		/**
+		Use a [Select/Set Graphic Rendition](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters) (SGR) [color code number](https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit) to set text color.
+
+		30 <= code && code < 38 || 90 <= code && code < 98
+		For example, 31 for red, 91 for redBright.
+		*/
+		ansi(code: number): Chalk;
+
+		/**
 		Use a [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set text color.
 		*/
 		ansi256(index: number): Chalk;
@@ -265,6 +273,15 @@ declare namespace chalk {
 		Use HWB values to set background color.
 		*/
 		bgHwb(hue: number, whiteness: number, blackness: number): Chalk;
+
+		/**
+		Use a [Select/Set Graphic Rendition](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters) (SGR) [color code number](https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit) to set background color.
+
+		30 <= code && code < 38 || 90 <= code && code < 98
+		For example, 31 for red, 91 for redBright.
+		Use the foreground code, not the background code (for example, not 41, nor 101).
+		*/
+		bgAnsi(code: number): Chalk;
 
 		/**
 		Use a [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set background color.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -49,6 +49,7 @@ expectType<colorReturn>(chalk.rgb(0, 0, 0));
 expectType<colorReturn>(chalk.hsl(0, 0, 0));
 expectType<colorReturn>(chalk.hsv(0, 0, 0));
 expectType<colorReturn>(chalk.hwb(0, 0, 0));
+expectType<colorReturn>(chalk.ansi(30));
 expectType<colorReturn>(chalk.ansi256(0));
 expectType<colorReturn>(chalk.bgHex('#DEADED'));
 expectType<colorReturn>(chalk.bgKeyword('orange'));
@@ -56,6 +57,7 @@ expectType<colorReturn>(chalk.bgRgb(0, 0, 0));
 expectType<colorReturn>(chalk.bgHsl(0, 0, 0));
 expectType<colorReturn>(chalk.bgHsv(0, 0, 0));
 expectType<colorReturn>(chalk.bgHwb(0, 0, 0));
+expectType<colorReturn>(chalk.bgAnsi(30));
 expectType<colorReturn>(chalk.bgAnsi256(0));
 
 // -- Modifiers --

--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ The following color models can be used:
 - [`hsl`](https://en.wikipedia.org/wiki/HSL_and_HSV) - Example: `chalk.hsl(32, 100, 50).bold('Orange!')`
 - [`hsv`](https://en.wikipedia.org/wiki/HSL_and_HSV) - Example: `chalk.hsv(32, 100, 100).bold('Orange!')`
 - [`hwb`](https://en.wikipedia.org/wiki/HWB_color_model) - Example: `chalk.hwb(32, 0, 50).bold('Orange!')`
-- `ansi16`
+- [`ansi`](https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit) - Example: `chalk.ansi(31).bgAnsi(93)('red on yellowBright')`
 - [`ansi256`](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) - Example: `chalk.bgAnsi256(194)('Honeydew, more or less')`
 
 


### PR DESCRIPTION
Here are remaining methods, after I researched the meaning of the argument:

1. Add 2 type tests to `index.test-d.ts` which failed first
2. Add 2 declarations to `index.d.ts`
3. Add link and example to `readme.md`

Thank you very much for quick turn-around on #368 ❤️