### PR TITLE
Change `chalk.Level` from `const enum` to `enum`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare const enum LevelEnum {
+declare enum LevelEnum {
 	/**
 	All colors disabled.
 	*/


### PR DESCRIPTION
```
node_modules/chalk/index.d.ts(403,16): error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.
```

Fixes #382