### PR TITLE
Remove const from LevelEnum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare const enum LevelEnum {
+declare enum LevelEnum {
 	/**
 	All colors disabled.
 	*/


### PR DESCRIPTION
`const` is not required in front of `enum`. TS does not let you reassign an `enum` anyway, so this should provide better compatibility.

fixes: #382 