### PR TITLE
Use `Object.setPrototypeOf` as `__proto__` could potentially be disabled

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -139,9 +139,9 @@ const createBuilder = (self, _styler, _isEmpty) => {
 		return applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
 	};
 
-	// `__proto__` is used because we must return a function, but there is
+	// We alter the prototype because we must return a function, but there is
 	// no way to create a function with a different prototype
-	builder.__proto__ = proto; // eslint-disable-line no-proto
+	Object.setPrototypeOf(builder, proto);
 
 	builder._generator = self;
 	builder._styler = _styler;


### PR DESCRIPTION
Due to CVEs and accidents, Node is thinking of allowing disabling `Object.prototype.__proto__`. This PR achieves the same functionality using `Object.setPrototypeOf` which does not suffer the same issues and removes a lint error.

See: https://github.com/nodejs/node/issues/31951