### PR TITLE
fix: correct type declarations in isolated modules mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare const enum LevelEnum {
+declare enum LevelEnum {
 	/**
 	All colors disabled.
 	*/
@@ -400,7 +400,7 @@ This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
 declare const chalk: chalk.Chalk & chalk.ChalkFunction & {
 	supportsColor: chalk.ColorSupport | false;
-	Level: chalk.Level;
+	Level: typeof LevelEnum;
 	Color: Color;
 	ForegroundColor: ForegroundColor;
 	BackgroundColor: BackgroundColor;

--- a/index.d.ts
+++ b/index.d.ts
@@ -400,7 +400,7 @@ This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
 */
 declare const chalk: chalk.Chalk & chalk.ChalkFunction & {
 	supportsColor: chalk.ColorSupport | false;
-	Level: typeof LevelEnum;
+	Level: chalk.Level;
 	Color: Color;
 	ForegroundColor: ForegroundColor;
 	BackgroundColor: BackgroundColor;

--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
 			"unicorn/prefer-string-slice": "off",
 			"unicorn/prefer-includes": "off"
 		}
+	},
+	"tsd": {
+		"compilerOptions": {
+			"isolatedModules": true
+		}
 	}
 }


### PR DESCRIPTION
When compiling with `isolatedModules`, I get a type error from Chalk.

![image](https://user-images.githubusercontent.com/1404810/77358268-d44bd080-6d49-11ea-96bd-1b266512eb49.png)

This change fixes it.

https://www.typescriptlang.org/v2/en/tsconfig#isolatedModules