### PR TITLE
Support nested calls

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -136,10 +136,12 @@ const createStyler = (open, close, parent) => {
 const createBuilder = (self, _styler, _isEmpty) => {
 	const builder = (...arguments_) => {
 		if (arguments_.length === 1) {
-			return applyStyle(builder, String(arguments_[0]));
+			// Single argument is hot path, implicit coercion is faster than anything
+			// eslint-disable-next-line no-implicit-coercion
+			return applyStyle(builder, '' + arguments_[0]);
 		}
 
-		const [firstString] = arguments_;
+		const firstString = arguments_[0];
 
 		if (!Array.isArray(firstString)) {
 			// If chalk() was called by itself or with a string,

--- a/source/index.js
+++ b/source/index.js
@@ -58,7 +58,7 @@ function Chalk(options) {
 for (const [styleName, style] of Object.entries(ansiStyles)) {
 	styles[styleName] = {
 		get() {
-			const builder = createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty, styleName);
+			const builder = createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty);
 			Object.defineProperty(this, styleName, {value: builder});
 			return builder;
 		}
@@ -81,7 +81,7 @@ for (const model of usedModels) {
 			const {level} = this;
 			return function (...arguments_) {
 				const styler = createStyler(ansiStyles.color[levelMapping[level]][model](...arguments_), ansiStyles.color.close, this._styler);
-				return createBuilder(this, styler, this._isEmpty, model);
+				return createBuilder(this, styler, this._isEmpty);
 			};
 		}
 	};
@@ -94,7 +94,7 @@ for (const model of usedModels) {
 			const {level} = this;
 			return function (...arguments_) {
 				const styler = createStyler(ansiStyles.bgColor[levelMapping[level]][model](...arguments_), ansiStyles.bgColor.close, this._styler);
-				return createBuilder(this, styler, this._isEmpty, bgModel);
+				return createBuilder(this, styler, this._isEmpty);
 			};
 		}
 	};
@@ -133,7 +133,7 @@ const createStyler = (open, close, parent) => {
 	};
 };
 
-const createBuilder = (self, _styler, _isEmpty, styleName) => {
+const createBuilder = (self, _styler, _isEmpty) => {
 	const builder = (...arguments_) => {
 		if (arguments_.length === 1) {
 			// Single argument is hot path, implicit coercion is faster than anything
@@ -150,7 +150,7 @@ const createBuilder = (self, _styler, _isEmpty, styleName) => {
 		}
 
 		arguments_ = arguments_.slice(1);
-		const parts = ['{' + styleName + ' ', firstString.raw[0]];
+		const parts = [firstString.raw[0]];
 
 		for (let i = 1; i < firstString.length; i++) {
 			parts.push(
@@ -159,13 +159,11 @@ const createBuilder = (self, _styler, _isEmpty, styleName) => {
 			);
 		}
 
-		parts.push('}');
-
 		if (template === undefined) {
 			template = require('./templates');
 		}
 
-		return template(chalk, parts.join(''));
+		return _styler.openAll + template(chalk, parts.join('')) + _styler.closeAll;
 	};
 
 	// We alter the prototype because we must return a function, but there is

--- a/source/index.js
+++ b/source/index.js
@@ -58,7 +58,7 @@ function Chalk(options) {
 for (const [styleName, style] of Object.entries(ansiStyles)) {
 	styles[styleName] = {
 		get() {
-			const builder = createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty);
+			const builder = createBuilder(this, createStyler(style.open, style.close, this._styler), this._isEmpty, styleName);
 			Object.defineProperty(this, styleName, {value: builder});
 			return builder;
 		}
@@ -81,7 +81,7 @@ for (const model of usedModels) {
 			const {level} = this;
 			return function (...arguments_) {
 				const styler = createStyler(ansiStyles.color[levelMapping[level]][model](...arguments_), ansiStyles.color.close, this._styler);
-				return createBuilder(this, styler, this._isEmpty);
+				return createBuilder(this, styler, this._isEmpty, model);
 			};
 		}
 	};
@@ -94,7 +94,7 @@ for (const model of usedModels) {
 			const {level} = this;
 			return function (...arguments_) {
 				const styler = createStyler(ansiStyles.bgColor[levelMapping[level]][model](...arguments_), ansiStyles.bgColor.close, this._styler);
-				return createBuilder(this, styler, this._isEmpty);
+				return createBuilder(this, styler, this._isEmpty, bgModel);
 			};
 		}
 	};
@@ -133,7 +133,7 @@ const createStyler = (open, close, parent) => {
 	};
 };
 
-const createBuilder = (self, _styler, _isEmpty) => {
+const createBuilder = (self, _styler, _isEmpty, styleName) => {
 	const builder = (...arguments_) => {
 		if (arguments_.length === 1) {
 			// Single argument is hot path, implicit coercion is faster than anything
@@ -150,7 +150,7 @@ const createBuilder = (self, _styler, _isEmpty) => {
 		}
 
 		arguments_ = arguments_.slice(1);
-		const parts = [firstString.raw[0]];
+		const parts = ['{' + styleName + ' ', firstString.raw[0]];
 
 		for (let i = 1; i < firstString.length; i++) {
 			parts.push(
@@ -158,6 +158,8 @@ const createBuilder = (self, _styler, _isEmpty) => {
 				String(firstString.raw[i])
 			);
 		}
+
+		parts.push('}');
 
 		if (template === undefined) {
 			template = require('./templates');

--- a/test/template-literal.js
+++ b/test/template-literal.js
@@ -181,5 +181,6 @@ test('should support nested calls', t => {
 	const name = 'Sindre';
 	const exclamation = 'Neat';
 	const result = instance.bold`Hello, {cyan.inverse ${name}!} This is a test. {green ${exclamation}!}`;
-	t.is(result, '\u001B[1mHello, \u001B[22m\u001B[1m\u001B[36m\u001B[7mSindre!\u001B[27m\u001B[39m\u001B[22m\u001B[1m This is a test. \u001B[22m\u001B[1m\u001B[32mNeat!\u001B[39m\u001B[22m');
+
+	t.is(result, '\u001B[1mHello, \u001B[36m\u001B[7mSindre!\u001B[27m\u001B[39m This is a test. \u001B[32mNeat!\u001B[39m\u001B[22m');
 });

--- a/test/template-literal.js
+++ b/test/template-literal.js
@@ -175,3 +175,11 @@ test('should allow bracketed Unicode escapes', t => {
 	t.is(instance`This is a {bold \u{AB681}} test`, 'This is a \u001B[1m\u{AB681}\u001B[22m test');
 	t.is(instance`This is a {bold \u{10FFFF}} test`, 'This is a \u001B[1m\u{10FFFF}\u001B[22m test');
 });
+
+test('should support nested calls', t => {
+	const instance = new chalk.Instance({level: 3});
+	const name = 'Sindre';
+	const exclamation = 'Neat';
+	const result = instance.bold`{bold Hello, {cyan.inverse ${name}!} This is a test. {green ${exclamation}!}}`;
+	t.is(result, '\u001B[1mHello, \u001B[22m\u001B[1m\u001B[36m\u001B[7mSindre!\u001B[27m\u001B[39m\u001B[22m\u001B[1m This is a test. \u001B[22m\u001B[1m\u001B[32mNeat!\u001B[39m\u001B[22m');
+});

--- a/test/template-literal.js
+++ b/test/template-literal.js
@@ -180,6 +180,6 @@ test('should support nested calls', t => {
 	const instance = new chalk.Instance({level: 3});
 	const name = 'Sindre';
 	const exclamation = 'Neat';
-	const result = instance.bold`{bold Hello, {cyan.inverse ${name}!} This is a test. {green ${exclamation}!}}`;
+	const result = instance.bold`Hello, {cyan.inverse ${name}!} This is a test. {green ${exclamation}!}`;
 	t.is(result, '\u001B[1mHello, \u001B[22m\u001B[1m\u001B[36m\u001B[7mSindre!\u001B[27m\u001B[39m\u001B[22m\u001B[1m This is a test. \u001B[22m\u001B[1m\u001B[32mNeat!\u001B[39m\u001B[22m');
 });


### PR DESCRIPTION
Fixes for #341 

Benchmark:
From this Pull Request:
```
      26,884,850 op/s » 1 style
      24,148,076 op/s » 2 styles
      21,742,104 op/s » 3 styles
      26,739,202 op/s » cached: 1 style
      24,135,040 op/s » cached: 2 styles
      22,669,978 op/s » cached: 3 styles
      10,143,420 op/s » cached: 1 style with newline
       5,015,684 op/s » cached: 1 style nested intersecting
      13,039,434 op/s » cached: 1 style nested non-intersecting


  Suites:  1
  Benches: 9
  Elapsed: 7,992.41 ms
```

From master:
```
      24,860,725 op/s » 1 style
      23,484,116 op/s » 2 styles
      20,689,530 op/s » 3 styles
      26,039,018 op/s » cached: 1 style
      23,091,189 op/s » cached: 2 styles
      21,367,378 op/s » cached: 3 styles
       9,357,187 op/s » cached: 1 style with newline
       5,068,170 op/s » cached: 1 style nested intersecting
      13,006,792 op/s » cached: 1 style nested non-intersecting


  Suites:  1
  Benches: 9
  Elapsed: 7,984.43 ms
```


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#341: Template literals are unsupported for nested calls](https://issuehunt.io/repos/11855195/issues/341)
---
</details>
<!-- /Issuehunt content-->