### PR TITLE
Remove fixed number of iterations from benchmark.js

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,10 +1,8 @@
-/* globals suite, set, bench */
+/* globals suite, bench */
 'use strict';
 const chalk = require('.');
 
 suite('chalk', () => {
-	set('iterations', 1000000);
-
 	const chalkRed = chalk.red;
 	const chalkBgRed = chalk.bgRed;
 	const chalkBlueBgRed = chalk.blue.bgRed;
@@ -47,8 +45,6 @@ suite('chalk', () => {
 	bench('cached: 1 style nested non-intersecting', () => {
 		chalkBgRed(blueStyledString);
 	});
-
-	set('iterations', 10000);
 
 	bench('cached: 1 style template literal', () => {
 		// eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
As suggested in https://github.com/chalk/chalk/pull/392#discussion_r437126403 the fixed number of iterations is removed.

@Qix- There are two possibilities:
- We could rely on the defaults of matcha (https://github.com/logicalparadox/matcha#defaults):
```javascript
set('iterations', 100);     // the number of times to run a given bench
set('concurrency', 1);      // the number of how many times a given bench is run concurrently
set('type', 'adaptive');    // or 'static' (see below)
set('mintime', 500);        // when adaptive, the minimum time in ms a bench should run
set('delay', 100);          // time in ms between each bench
```
- Or we could provide our own.

I like the defaults best. So I just removed the two lines where we fix the number of iterations.