### PR TITLE
Added chalk.parse function to style any string using html-like tags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,13 @@ RAM: {green ${ram.used / ram.total * 100}%}
 DISK: {rgb(255,131,0) ${disk.used / disk.total * 100}%}
 `);
 
+// Nestable style tags
+log(chalk.parse(`
+  <green>
+    Aren't you glad I didn't say <bold.keyword('orange').underline>Naranja!</>
+  </>
+`));
+
 // Use RGB colors in terminal emulators that support it.
 log(chalk.keyword('orange')('Yay for orange colored text!'));
 log(chalk.rgb(123, 45, 67).underline('Underlined reddish color'));
@@ -226,6 +233,25 @@ console.log(chalk`{bold.rgb(10,100,200) Hello!}`);
 Note that function styles (`rgb()`, `hsl()`, `keyword()`, etc.) may not contain spaces between parameters.
 
 All interpolated values (`` chalk`${foo}` ``) are converted to strings via the `.toString()` method. All curly braces (`{` and `}`) in interpolated value strings are escaped.
+
+## Style tags
+
+You can quickly stylize any string that uses html-like tags
+
+```js
+const chalk = require('chalk');
+
+const example1 = '<bold.green>Well that is <bgYellow.underline.dim.blink.black>convinient!</></>'
+const example2 = '<bold.rgb(1,4,50).underline>All functions are supported</>'
+
+console.log(chalk.parse(example1));
+console.log(chalk.parse(example2));
+```
+
+- Style tags always come in pairs: An **opening tag** followed by a **closing tag**.
+- The **opening tag** name is any style/modifier that is listed above and multiple styles can be chained using a dot.
+- The **closing tag** name does not require a matching name, unlike html.
+- Styles will cascade, in other words: child tags, as well as sibling tags or text will inherit a parent tag's style.
 
 ## 256 and Truecolor color support
 

--- a/source/index.js
+++ b/source/index.js
@@ -19,22 +19,22 @@ const levelMapping = [
 const styles = Object.create(null);
 
 function parseTaggedString(string) {
-  const tagPattern = /\<([\w, '().]+)\>([\s\S]+)\<\/\w*\>/g;
-  const callPattern = /\((.*)\)/;
-  return string.replace(tagPattern, (_, color, text) => {
-    let carbonate = chalk;
-    color.split('.').forEach(c => {
-      if (callPattern.test(c)) {
-        const args = JSON.parse(`[${ callPattern.exec(c)[1].replace(/'/g, '"') }]`);
-        c = /(\w+)/g.exec(c)[0];
-        carbonate = carbonate[c] ? carbonate[c].apply(carbonate[c], args) : carbonate;
-      } else {
-        carbonate = carbonate[c] || carbonate;
-      }
-    });
-    text = carbonate(text);
-    return tagPattern.test(text) ? parseTaggedString(text) : text;
-  });
+	const tagPattern = /<([\w, '().]+)>([\s\S]+)<\/\w*>/g;
+	const callPattern = /\((.*)\)/;
+	return string.replace(tagPattern, (_, color, text) => {
+		let carbonate = chalk;
+		color.split('.').forEach(c => {
+			if (callPattern.test(c)) {
+				const args = JSON.parse(`[${callPattern.exec(c)[1].replace(/'/g, '"')}]`);
+				c = /(\w+)/g.exec(c)[0];
+				carbonate = carbonate[c] ? carbonate[c].apply(carbonate[c], args) : carbonate;
+			} else {
+				carbonate = carbonate[c] || carbonate;
+			}
+		});
+		text = carbonate(text);
+		return tagPattern.test(text) ? parseTaggedString(text) : text;
+	});
 }
 
 const applyOptions = (object, options = {}) => {
@@ -68,7 +68,7 @@ const chalkFactory = options => {
 	};
 
 	chalk.template.Instance = ChalkClass;
-	
+
 	chalk.template.parse = parseTaggedString;
 
 	return chalk.template;


### PR DESCRIPTION
Added chalk.parse function in `source/index.js` and updated `readme.md` to reflect added functionality.

This is a tiny function that will allow you to quickly stylize any string, perhaps from an external file using all current and future chalk styles and modifiers with or w/out parameters.

It uses a familiar syntax: html, and allows you to write intuitive nestable styled strings, alot like writing html in fact.

**Test it out**


1. Create *test.js* (code below)
2. npm i chalk
3. node test.js

```js
const chalk = require('chalk');

function parseTaggedString(string) {
  const tagPattern = /\<([\w, '().]+)\>([\s\S]+)\<\/\w*\>/g;
  const callPattern = /\((.*)\)/;
  return string.replace(tagPattern, (_, color, text) => {
    let carbonate = chalk;
    color.split('.').forEach(c => {
      if (callPattern.test(c)) {
        const args = JSON.parse(`[${ callPattern.exec(c)[1].replace(/'/g, '"') }]`);
        c = /(\w+)/g.exec(c)[0];
        carbonate = carbonate[c] ? carbonate[c].apply(carbonate[c], args) : carbonate;
      } else {
        carbonate = carbonate[c] || carbonate;
      }
    });
    text = carbonate(text);
    return tagPattern.test(text) ? parseTaggedString(text) : text;
  });
}

// Plain no markup
console.log(parseTaggedString(`
  Hello there care bear!
`));

// blue html-like markup
console.log(parseTaggedString(`
  Hello there care <blue>bear!</blue>
`));

// multiple chalk options & shorthand closing tag
console.log(parseTaggedString(`
  Hello there care <bold.white>bear!</>
`));

// multiple chalk options & shorthand closing tag, w/twist
// Last color overwrites previous colors
console.log(parseTaggedString(`
  Hello there care <bold.white.underline.red>bear!</>
`));

// what happenes when there is an invalid option? nuttin'
console.log(parseTaggedString(`
  Hello there care <ninja.power>bear!</>
`));

// Can it do multiple depths? Oh yeah!
console.log(parseTaggedString(`
  <red>Hello there care <bold.green>bear!</> </red>
`));

// It supports all current and future styles!
console.log(parseTaggedString(`
  <bold.bgRed.underline.green>It's future proofed</>
`));

// It supports all current and future styles!
console.log(parseTaggedString(`
  <bold.green>Well that is <bgYellow.underline.dim.blink.black>convinient!</></>
`));

// It supports all current and future styles! keyword()
console.log(parseTaggedString(`
  <bold.keyword('orange').underline>Naranja!</>
`));

// It supports all current and future styles! rgb()
console.log(parseTaggedString(`
  <bold.rgb(1,4,50).underline>All functions are supported</>
`));

```