### PR TITLE
Add browser support information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,7 +282,7 @@ The following color models can be used:
 
 ## Browser support
 
-Since Chrome 69 ANSI escape codes are natively supported in the terminal.
+Since Chrome 69, ANSI escape codes are natively supported in the developer console.
 
 ## Windows
 

--- a/readme.md
+++ b/readme.md
@@ -280,6 +280,10 @@ The following color models can be used:
 - [`ansi`](https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit) - Example: `chalk.ansi(31).bgAnsi(93)('red on yellowBright')`
 - [`ansi256`](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) - Example: `chalk.bgAnsi256(194)('Honeydew, more or less')`
 
+## Browser support
+
+Since Chrome 69 ANSI escape codes are natively supported in the terminal.
+
 ## Windows
 
 If you're on Windows, do yourself a favor and use [Windows Terminal](https://github.com/microsoft/terminal) instead of `cmd.exe`.


### PR DESCRIPTION
After some testing, I concluded that only Chrome 69 and later supported ANSI escape codes but not Firefox or Safari. I can't seem to find the release notes showing that the support was added but I have verified that the feature does not exist in Chrome 68.