### PR TITLE
round r,g,b values in 16-million color support

### DIFF
--- a/source/vendor/ansi-styles/index.js
+++ b/source/vendor/ansi-styles/index.js
@@ -4,7 +4,7 @@ const wrapAnsi16 = (offset = 0) => code => `\u001B[${code + offset}m`;
 
 const wrapAnsi256 = (offset = 0) => code => `\u001B[${38 + offset};5;${code}m`;
 
-const wrapAnsi16m = (offset = 0) => (red, green, blue) => `\u001B[${38 + offset};2;${red};${green};${blue}m`;
+const wrapAnsi16m = (offset = 0) => (red, green, blue) => `\u001B[${38 + offset};2;${Math.round(red)};${Math.round(green)};${Math.round(blue)}m`;
 
 function assembleStyles() {
 	const codes = new Map();


### PR DESCRIPTION
Currently if you pass decimal values to rgb or bgRgb, it will generate output with those decimals, which iTerm silently ignores.

Not sure if this is the ideal fix, since when rgb values are from 0-255 it's *commonly* assumed that they're integers. Maybe chalk should just throw an error instead. But this is a bug I came across when converting from 0-1 r,g,b, which is common, so there should be at least some indication.