### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/source/utilities.js
+++ b/source/utilities.js
@@ -9,7 +9,7 @@ export function stringReplaceAll(string, substring, replacer) {
 	let endIndex = 0;
 	let returnValue = '';
 	do {
-		returnValue += string.substr(endIndex, index - endIndex) + substring + replacer;
+		returnValue += string.slice(endIndex, index) + substring + replacer;
 		endIndex = index + substringLength;
 		index = string.indexOf(substring, endIndex);
 	} while (index !== -1);
@@ -23,7 +23,7 @@ export function stringEncaseCRLFWithFirstIndex(string, prefix, postfix, index) {
 	let returnValue = '';
 	do {
 		const gotCR = string[index - 1] === '\r';
-		returnValue += string.substr(endIndex, (gotCR ? index - 1 : index) - endIndex) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
+		returnValue += string.slice(endIndex, (gotCR ? index - 1 : index)) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
 		endIndex = index + 1;
 		index = string.indexOf('\n', endIndex);
 	} while (index !== -1);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.