### PR TITLE
Use template literal types for simple color name transformations.

### DIFF
--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -2,55 +2,24 @@
 // import {ColorInfo, ColorSupportLevel} from '#supports-color';
 import {ColorInfo, ColorSupportLevel} from './vendor/supports-color/index.js';
 
+type BasicColor =  'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white';
+type BrightColor = `${BasicColor}Bright`;
+type Grey = 'gray' | 'grey';
+
 /**
 Basic foreground colors.
 
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
-export type ForegroundColor =
-	| 'black'
-	| 'red'
-	| 'green'
-	| 'yellow'
-	| 'blue'
-	| 'magenta'
-	| 'cyan'
-	| 'white'
-	| 'gray'
-	| 'grey'
-	| 'blackBright'
-	| 'redBright'
-	| 'greenBright'
-	| 'yellowBright'
-	| 'blueBright'
-	| 'magentaBright'
-	| 'cyanBright'
-	| 'whiteBright';
+
+export type ForegroundColor = BasicColor | BrightColor | Grey;
 
 /**
 Basic background colors.
 
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
-export type BackgroundColor =
-	| 'bgBlack'
-	| 'bgRed'
-	| 'bgGreen'
-	| 'bgYellow'
-	| 'bgBlue'
-	| 'bgMagenta'
-	| 'bgCyan'
-	| 'bgWhite'
-	| 'bgGray'
-	| 'bgGrey'
-	| 'bgBlackBright'
-	| 'bgRedBright'
-	| 'bgGreenBright'
-	| 'bgYellowBright'
-	| 'bgBlueBright'
-	| 'bgMagentaBright'
-	| 'bgCyanBright'
-	| 'bgWhiteBright';
+export type BackgroundColor = `bg${Capitalize<ForegroundColor>}`;
 
 /**
 Basic colors.

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -2,7 +2,7 @@
 // import {ColorInfo, ColorSupportLevel} from '#supports-color';
 import {ColorInfo, ColorSupportLevel} from './vendor/supports-color/index.js';
 
-type BasicColor =  'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white';
+type BasicColor = 'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white';
 type BrightColor = `${BasicColor}Bright`;
 type Grey = 'gray' | 'grey';
 


### PR DESCRIPTION
For simple type transformations - `<color> -> bg<Color>`, for example - we can use [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) instead of multiple string literal type unions. An advantage of this approach is that the template literal types are always derived from the interpolated types, which means that we don't have to worry about missing types or misspelling types when performing these transformations.