### PR TITLE
Bring colors to bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"#ansi-styles": "./source/vendor/ansi-styles/index.js",
 		"#supports-color": {
 			"node": "./source/vendor/supports-color/index.js",
+			"bun": "./source/vendor/supports-color/index.js",
 			"default": "./source/vendor/supports-color/browser.js"
 		}
 	},


### PR DESCRIPTION
[Bun](https://bun.sh) is a new javascript runtime.
It supports ansi colors and could work with chalk.
Chalk checks for color support with a version of `supports-color` which is imported via an import field.
Bun looks for a "bun" subpath of an import and uses "default" if it doesn't find it; it ignores "node" completely.

This PR just adds a "bun" subpath of the `#supports-color` import field and points it to the same file as "node". This then shows the correct color support data for bun.