### PR TITLE
Update `supports-color` to 9.4.0

### DIFF
--- a/source/vendor/supports-color/browser.js
+++ b/source/vendor/supports-color/browser.js
@@ -3,7 +3,7 @@
 const level = (() => {
 	if (navigator.userAgentData) {
 		const brand = navigator.userAgentData.brands.find(({brand}) => brand === 'Chromium');
-		if (brand && brand.version > 93) {
+		if (brand?.version > 93) {
 			return 3;
 		}
 	}

--- a/source/vendor/supports-color/index.d.ts
+++ b/source/vendor/supports-color/index.d.ts
@@ -1,13 +1,13 @@
 import type {WriteStream} from 'node:tty';
 
-export interface Options {
+export type Options = {
 	/**
 	Whether `process.argv` should be sniffed for `--color` and `--no-color` flags.
 
 	@default true
 	*/
 	readonly sniffFlags?: boolean;
-}
+};
 
 /**
 Levels:
@@ -21,7 +21,7 @@ export type ColorSupportLevel = 0 | 1 | 2 | 3;
 /**
 Detect whether the terminal supports color.
 */
-export interface ColorSupport {
+export type ColorSupport = {
 	/**
 	The color level.
 	*/
@@ -41,7 +41,7 @@ export interface ColorSupport {
 	Whether Truecolor 16 million colors are supported.
 	*/
 	has16m: boolean;
-}
+};
 
 export type ColorInfo = ColorSupport | false;
 

--- a/source/vendor/supports-color/index.d.ts
+++ b/source/vendor/supports-color/index.d.ts
@@ -1,13 +1,13 @@
 import type {WriteStream} from 'node:tty';
 
-export type Options = {
+export interface Options {
 	/**
 	Whether `process.argv` should be sniffed for `--color` and `--no-color` flags.
 
 	@default true
 	*/
 	readonly sniffFlags?: boolean;
-};
+}
 
 /**
 Levels:
@@ -21,7 +21,7 @@ export type ColorSupportLevel = 0 | 1 | 2 | 3;
 /**
 Detect whether the terminal supports color.
 */
-export type ColorSupport = {
+export interface ColorSupport {
 	/**
 	The color level.
 	*/
@@ -41,7 +41,7 @@ export type ColorSupport = {
 	Whether Truecolor 16 million colors are supported.
 	*/
 	has16m: boolean;
-};
+}
 
 export type ColorInfo = ColorSupport | false;
 

--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -3,6 +3,7 @@ import os from 'node:os';
 import tty from 'node:tty';
 
 // From: https://github.com/sindresorhus/has-flag/blob/main/index.js
+/// function hasFlag(flag, argv = globalThis.Deno?.args ?? process.argv) {
 function hasFlag(flag, argv = globalThis.Deno ? globalThis.Deno.args : process.argv) {
 	const prefix = flag.startsWith('-') ? '' : (flag.length === 1 ? '-' : '--');
 	const position = argv.indexOf(prefix + flag);
@@ -111,7 +112,7 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 	}
 
 	if ('CI' in env) {
-		if ('GITHUB_ACTIONS' in env) {
+		if ('GITHUB_ACTIONS' in env || 'GITEA_ACTIONS' in env) {
 			return 3;
 		}
 


### PR DESCRIPTION
Produced via `cp ../supports-color/{index,browser}.{js,d.ts} source/vendor/supports-color`.

Includes https://github.com/chalk/supports-color/pull/148.