### PR TITLE
Remove `.replit` file

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "nodejs"
-run = "cd examples && node rainbow"


### PR DESCRIPTION
As noted in #587, the Replit demo no longer works anymore. f7b29ae8ef4fd2048e08aa361778d290ed10ce7a partially fixes this, but the `.replit` file still remains. Even importing the GitHub project manually results in an error:

![image](https://github.com/chalk/chalk/assets/24364012/4003b0c1-b230-4a7b-a083-e8cdb22d35b4)

When the original PR was made, iirc dependencies were installed automatically. There are other things to note, too. In the `.replit` file, there is a similar `deployments.run` property which has similar functionality. As mentioned in the original issue, using replit to run the example now requires an account. I think these issues, along with the removal of the badge, suggests that the `.replit` file should be removed. Besides, there are better alternatives, like RunKit, or StackBlitz as mentioned previously.