### PR TITLE
Add `material-chalk` to ecosystem list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,7 +288,7 @@ If absolute package size is important to you, I also maintain [yoctocolors](http
 - [gradient-string](https://github.com/bokub/gradient-string) - Apply color gradients to strings
 - [chalk-pipe](https://github.com/LitoMore/chalk-pipe) - Create chalk style schemes with simpler style strings
 - [terminal-link](https://github.com/sindresorhus/terminal-link) - Create clickable links in the terminal
-- [material-chalk](https://www.npmjs.com/package/material-chalk) - Create colors with consistent brightness following Material Design
+- [material-chalk](https://github.com/SebastienGllmt/material-chalk) - Create colors with consistent brightness following Material Design
 
 ## Maintainers
 

--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,7 @@ If absolute package size is important to you, I also maintain [yoctocolors](http
 - [gradient-string](https://github.com/bokub/gradient-string) - Apply color gradients to strings
 - [chalk-pipe](https://github.com/LitoMore/chalk-pipe) - Create chalk style schemes with simpler style strings
 - [terminal-link](https://github.com/sindresorhus/terminal-link) - Create clickable links in the terminal
+- [material-chalk](https://www.npmjs.com/package/material-chalk) - Create colors with consistent brightness following Material Design
 
 ## Maintainers
 


### PR DESCRIPTION
I created a package that builds on top of `chalk` called `material-chalk`. It allows generating colors with consistent brightness for namespaces which helps a lot make logs readable in complex projects with many components

- NPM package: [link](https://www.npmjs.com/package/material-chalk)
- Write-up on the color theory behind the NPM package: [link](https://github.com/SebastienGllmt/material-chalk/blob/master/Justifications.md)

Thanks for building chalk!