### PR TITLE
Fix `navigator` not defined `ReferenceError`

### DIFF
--- a/source/vendor/supports-color/browser.js
+++ b/source/vendor/supports-color/browser.js
@@ -1,14 +1,18 @@
 /* eslint-env browser */
 
 const level = (() => {
-	if (navigator.userAgentData) {
+	if (!('navigator' in globalThis)) {
+		return 0;
+	}
+
+	if (globalThis.navigator.userAgentData) {
 		const brand = navigator.userAgentData.brands.find(({brand}) => brand === 'Chromium');
 		if (brand && brand.version > 93) {
 			return 3;
 		}
 	}
 
-	if (/\b(Chrome|Chromium)\//.test(navigator.userAgent)) {
+	if (/\b(Chrome|Chromium)\//.test(globalThis.navigator.userAgent)) {
 		return 1;
 	}
 


### PR DESCRIPTION
This is a follow-up to #640 that will fix #639

In this PR, I applied the fix for the potentially `undefined` `navigator` in the same way [that was done in `supports-color`](https://github.com/chalk/supports-color/commit/c214314a14bcb174b12b3014b2b0a8de375029ae)

- Related to https://github.com/chalk/supports-color/pull/151
- `supports-color`'s v10.0.0 diff: https://github.com/chalk/supports-color/compare/v9.4.0...v10.0.0

