### PR TITLE
Ghostty supports truecolor

### DIFF
--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -135,6 +135,10 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		return 3;
 	}
 
+	if (env.TERM === 'xterm-ghostty') {
+		return 3;
+	}
+
 	if ('TERM_PROGRAM' in env) {
 		const version = Number.parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);
 


### PR DESCRIPTION
ghostty is a newer popular terminal emulator https://github.com/ghostty-org/ghostty/

it uses `xterm-ghostty` for TERM

it supports truecolor, and I see you already have a hack for kitty so might as well add one for ghostty