### PR TITLE
docs: fix spacing inconsistency in Modifiers section (#663)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,10 +178,10 @@ console.log(foregroundColorNames.includes('pink'));
 - `italic` - Make the text italic. *(Not widely supported)*
 - `underline` - Put a horizontal line below the text. *(Not widely supported)*
 - `overline` - Put a horizontal line above the text. *(Not widely supported)*
-- `inverse`- Invert background and foreground colors.
+- `inverse` - Invert background and foreground colors.
 - `hidden` - Print the text but make it invisible.
 - `strikethrough` - Puts a horizontal line through the center of the text. *(Not widely supported)*
-- `visible`- Print the text only when Chalk has a color level above zero. Can be useful for things that are purely cosmetic.
+- `visible` - Print the text only when Chalk has a color level above zero. Can be useful for things that are purely cosmetic.
 
 ### Colors
 


### PR DESCRIPTION
This PR fixes a minor formatting issue in `README.md` where two entries in the **Modifiers** section were missing a space between the inline code block and the description hyphen. 

This ensures visual consistency with the rest of the modifier list (e.g., `bold`, `dim`, `italic`).

### Changes
- Updated line 181: Added space after `inverse`
- Updated line 184: Added space after `visible`

### Before
- `inverse`- Invert background and foreground colors.
- `visible`- Print the text only when Chalk has a color level above zero.

### After
- `inverse` - Invert background and foreground colors.
- `visible` - Print the text only when Chalk has a color level above zero.

Fixes #663