### PR TITLE
Fix FORCE_COLOR override when COLORTERM is set

### DIFF
--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -81,6 +81,12 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		}
 	}
 
+	// If FORCE_COLOR is explicitly set, return it immediately
+	// to prevent terminal detection from overriding it
+	if (forceColor !== undefined) {
+		return forceColor;
+	}
+
 	// Check for Azure DevOps pipelines.
 	// Has to be above the `!streamIsTTY` check.
 	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {


### PR DESCRIPTION
## Summary

Fixes #624 - When `COLORTERM=truecolor` is set, `FORCE_COLOR=1` and `FORCE_COLOR=2` now correctly return levels 1 and 2 instead of being overridden to level 3.

## Changes

Added an early return in `_supportsColor()` when `FORCE_COLOR` is explicitly set, preventing terminal detection logic from overriding the user's explicit choice. This ensures `FORCE_COLOR` takes priority over automatic terminal capability detection.

## Test Results

Manual testing confirms the fix works:

```bash
# With COLORTERM=truecolor set
COLORTERM=truecolor FORCE_COLOR=0 node test.mjs
# Output: supportsColor: false

COLORTERM=truecolor FORCE_COLOR=1 node test.mjs
# Output: supportsColor: { level: 1, hasBasic: true, has256: false, has16m: false }

COLORTERM=truecolor FORCE_COLOR=2 node test.mjs
# Output: supportsColor: { level: 2, hasBasic: true, has256: true, has16m: false }

COLORTERM=truecolor FORCE_COLOR=3 node test.mjs
# Output: supportsColor: { level: 3, hasBasic: true, has256: true, has16m: true }
```

All existing tests continue to pass.