### PR TITLE
Fix FORCE_COLOR to set exact level instead of minimum

### DIFF
--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -91,7 +91,15 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		return 0;
 	}
 
-	const min = forceColor || 0;
+	// When `FORCE_COLOR` is set to a specific level, return that level
+	// directly instead of using it as a minimum. This ensures that
+	// e.g. FORCE_COLOR=1 gives exactly level 1, not a higher level
+	// based on terminal capabilities.
+	if (forceColor !== undefined) {
+		return forceColor;
+	}
+
+	const min = 0;
 
 	if (env.TERM === 'dumb') {
 		return min;

--- a/test/_force-color-fixture.js
+++ b/test/_force-color-fixture.js
@@ -1,0 +1,4 @@
+import {createSupportsColor} from '../source/vendor/supports-color/index.js';
+
+const result = createSupportsColor({isTTY: true});
+console.log(JSON.stringify(result));

--- a/test/force-color.js
+++ b/test/force-color.js
@@ -1,0 +1,45 @@
+import {fileURLToPath} from 'node:url';
+import test from 'ava';
+import {execaNode} from 'execa';
+
+const fixturePath = fileURLToPath(new URL('_force-color-fixture.js', import.meta.url));
+
+test('FORCE_COLOR=0 disables color support', async t => {
+	const {stdout} = await execaNode(fixturePath, {
+		env: {FORCE_COLOR: '0', COLORTERM: 'truecolor'},
+	});
+	t.is(stdout, 'false');
+});
+
+test('FORCE_COLOR=1 gives exactly level 1 even with truecolor terminal', async t => {
+	const {stdout} = await execaNode(fixturePath, {
+		env: {FORCE_COLOR: '1', COLORTERM: 'truecolor'},
+	});
+	const result = JSON.parse(stdout);
+	t.is(result.level, 1);
+	t.true(result.hasBasic);
+	t.false(result.has256);
+	t.false(result.has16m);
+});
+
+test('FORCE_COLOR=2 gives exactly level 2 even with truecolor terminal', async t => {
+	const {stdout} = await execaNode(fixturePath, {
+		env: {FORCE_COLOR: '2', COLORTERM: 'truecolor'},
+	});
+	const result = JSON.parse(stdout);
+	t.is(result.level, 2);
+	t.true(result.hasBasic);
+	t.true(result.has256);
+	t.false(result.has16m);
+});
+
+test('FORCE_COLOR=3 gives exactly level 3', async t => {
+	const {stdout} = await execaNode(fixturePath, {
+		env: {FORCE_COLOR: '3'},
+	});
+	const result = JSON.parse(stdout);
+	t.is(result.level, 3);
+	t.true(result.hasBasic);
+	t.true(result.has256);
+	t.true(result.has16m);
+});


### PR DESCRIPTION
When `FORCE_COLOR` is set to a specific level like `1` or `2`, the expected behavior is that the color support level is forced to exactly that value. However, `FORCE_COLOR` was being used as a floor/minimum value in `_supportsColor`, meaning terminal capability detection could still return a higher level.

For example, on a terminal with `COLORTERM=truecolor`, setting `FORCE_COLOR=1` would still give level 3 because the truecolor check fires after the minimum is set.

The fix makes `_supportsColor` return the forced level directly when `FORCE_COLOR` is explicitly set, skipping the terminal detection logic entirely. This matches the expected semantics — "force" means force to this exact level, not "ensure at least this level."

**Before:**
```
FORCE_COLOR=1 (with COLORTERM=truecolor) => level 3
FORCE_COLOR=2 (with COLORTERM=truecolor) => level 3
```

**After:**
```
FORCE_COLOR=1 (with COLORTERM=truecolor) => level 1
FORCE_COLOR=2 (with COLORTERM=truecolor) => level 2
```

Fixes #624