### PR TITLE
Fix security and performance issues (S2–S6, P1, P4, P6)

### DIFF
--- a/examples/rainbow.js
+++ b/examples/rainbow.js
@@ -15,7 +15,7 @@ function rainbow(string, offset) {
 	let hue = offset % 360;
 	const characters = [];
 	for (const character of string) {
-		if (ignoreChars.test(character)) {
+		if (character < '!' || character > '~') {
 			characters.push(character);
 		} else {
 			characters.push(chalk.hex(convertColor.hsl.hex(hue, 100, 50))(character));

--- a/source/index.js
+++ b/source/index.js
@@ -22,7 +22,7 @@ const levelMapping = [
 const styles = Object.create(null);
 
 const applyOptions = (object, options = {}) => {
-	if (options.level && !(Number.isInteger(options.level) && options.level >= 0 && options.level <= 3)) {
+	if (options.level !== undefined && !(Number.isInteger(options.level) && options.level >= 0 && options.level <= 3)) {
 		throw new Error('The `level` option should be an integer from 0 to 3');
 	}
 
@@ -151,8 +151,15 @@ const createStyler = (open, close, parent) => {
 
 const createBuilder = (self, _styler, _isEmpty) => {
 	// Single argument is hot path, implicit coercion is faster than anything
-	// eslint-disable-next-line no-implicit-coercion
-	const builder = (...arguments_) => applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
+	const builder = (...arguments_) => {
+		// Tagged template literal: first argument is a strings array with a `.raw` property
+		if (arguments_.length > 0 && Array.isArray(arguments_[0]) && 'raw' in arguments_[0]) {
+			return applyStyle(builder, String.raw(arguments_[0], ...arguments_.slice(1)));
+		}
+
+		// eslint-disable-next-line no-implicit-coercion
+		return applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
+	};
 
 	// We alter the prototype because we must return a function, but there is
 	// no way to create a function with a different prototype

--- a/source/utilities.js
+++ b/source/utilities.js
@@ -20,14 +20,14 @@ export function stringReplaceAll(string, substring, replacer) {
 
 export function stringEncaseCRLFWithFirstIndex(string, prefix, postfix, index) {
 	let endIndex = 0;
-	let returnValue = '';
+	const parts = [];
 	do {
 		const gotCR = string[index - 1] === '\r';
-		returnValue += string.slice(endIndex, (gotCR ? index - 1 : index)) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
+		parts.push(string.slice(endIndex, gotCR ? index - 1 : index), prefix, gotCR ? '\r\n' : '\n', postfix);
 		endIndex = index + 1;
 		index = string.indexOf('\n', endIndex);
 	} while (index !== -1);
 
-	returnValue += string.slice(endIndex);
-	return returnValue;
+	parts.push(string.slice(endIndex));
+	return parts.join('');
 }

--- a/source/vendor/ansi-styles/index.js
+++ b/source/vendor/ansi-styles/index.js
@@ -133,7 +133,8 @@ function assembleStyles() {
 		},
 		hexToRgb: {
 			value(hex) {
-				const matches = /[a-f\d]{6}|[a-f\d]{3}/i.exec(hex.toString(16));
+				const hexString = typeof hex === 'number' ? hex.toString(16).padStart(6, '0') : String(hex);
+				const matches = /[a-f\d]{6}|[a-f\d]{3}/i.exec(hexString);
 				if (!matches) {
 					return [0, 0, 0];
 				}

--- a/source/vendor/supports-color/browser.js
+++ b/source/vendor/supports-color/browser.js
@@ -7,7 +7,7 @@ const level = (() => {
 
 	if (globalThis.navigator.userAgentData) {
 		const brand = navigator.userAgentData.brands.find(({brand}) => brand === 'Chromium');
-		if (brand && brand.version > 93) {
+		if (brand && Number(brand.version) > 93) {
 			return 3;
 		}
 	}

--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -40,7 +40,8 @@ function envForceColor() {
 			return 0;
 		}
 
-		return env.FORCE_COLOR.length === 0 ? 1 : Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+		const parsed = Number.parseInt(env.FORCE_COLOR, 10);
+		return env.FORCE_COLOR.length === 0 ? 1 : (Number.isNaN(parsed) ? 1 : Math.min(parsed, 3));
 	}
 }
 
@@ -58,12 +59,8 @@ function translateLevel(level) {
 }
 
 function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
-	const noFlagForceColor = envForceColor();
-	if (noFlagForceColor !== undefined) {
-		flagForceColor = noFlagForceColor;
-	}
-
-	const forceColor = sniffFlags ? flagForceColor : noFlagForceColor;
+	const envColor = envForceColor();
+	const forceColor = sniffFlags ? (envColor === undefined ? flagForceColor : envColor) : envColor;
 
 	if (forceColor === 0) {
 		return 0;

--- a/test/chalk.js
+++ b/test/chalk.js
@@ -124,3 +124,22 @@ test('keeps function prototype methods', t => {
 	t.is(chalk.bind(chalk, 'foo')(), 'foo');
 	t.is(chalk.call(chalk, 'foo'), 'foo');
 });
+
+test('accept numeric hex values in .hex() (S2)', t => {
+	// Numeric values should behave identically to their string equivalents
+	t.is(new Chalk({level: 3}).hex(0xFF_00_00)('hello'), new Chalk({level: 3}).hex('#FF0000')('hello'));
+	t.is(new Chalk({level: 3}).bgHex(0xFF_00_FF)('hello'), new Chalk({level: 3}).bgHex('#FF00FF')('hello'));
+	// Leading zeros must be preserved: 0x0000FF is blue, not a garbled 3-char match
+	t.is(new Chalk({level: 3}).hex(0x00_00_FF)('hello'), new Chalk({level: 3}).hex('#0000FF')('hello'));
+	t.is(new Chalk({level: 3}).hex(0x00_FF_00)('hello'), new Chalk({level: 3}).hex('#00FF00')('hello'));
+});
+
+test('support tagged template literals with interpolations (P6)', t => {
+	const name = 'World';
+	t.is(chalk.red`hello ${name}`, '\u001B[31mhello World\u001B[39m');
+	t.is(chalk.bold`count: ${42}`, '\u001B[1mcount: 42\u001B[22m');
+	// Without interpolations should still work
+	t.is(chalk.red`hello`, '\u001B[31mhello\u001B[39m');
+	// Array arguments (not template literals) must be unaffected
+	t.is(chalk.bold(['foo', 'bar']), '\u001B[1mfoo,bar\u001B[22m');
+});

--- a/test/instance.js
+++ b/test/instance.js
@@ -22,3 +22,15 @@ test('the `level` option should be a number from 0 to 3', t => {
 	}, {message: /should be an integer from 0 to 3/});
 	/* eslint-enable no-new */
 });
+
+test('the `level` option rejects null and NaN (S5)', t => {
+	/* eslint-disable no-new */
+	t.throws(() => {
+		new Chalk({level: null});
+	}, {message: /should be an integer from 0 to 3/});
+
+	t.throws(() => {
+		new Chalk({level: Number.NaN});
+	}, {message: /should be an integer from 0 to 3/});
+	/* eslint-enable no-new */
+});


### PR DESCRIPTION
## Summary

This PR addresses a set of security correctness issues and performance improvements found during a review of the codebase. All 35 existing tests continue to pass; three new regression tests are added.

### Security fixes

- **S2 — `hexToRgb` explicit type handling** (`ansi-styles/index.js`): The previous `hex.toString(16)` call was a no-op when `hex` was a string (strings ignore the radix argument), making the numeric-input path work only by accident. Now branches explicitly on `typeof hex === 'number'` and applies `.padStart(6, '0')` so leading zeros are preserved (e.g. `0x0000FF` → `"0000ff"` not `"ff"`).

- **S3 — `FORCE_COLOR` NaN propagation** (`supports-color/index.js`): `FORCE_COLOR=yes` (or any non-numeric string) caused `parseInt` to return `NaN`, which propagated through `Math.min` and `translateLevel` into a partially-truthy level object with `level: NaN`. Added `Number.isNaN` guard; invalid values now fall back to level `1`.

- **S4 — `_supportsColor` shared mutable state** (`supports-color/index.js`): `_supportsColor` had a hidden side effect — it overwrote the module-level `flagForceColor` variable (set from `process.argv` at load time) with the env-based value on every call. This could corrupt state across multiple calls in test environments that mock env vars. The effective value is now computed locally with no mutation.

- **S5 — `applyOptions` validation** (`index.js`): The guard `if (options.level && …)` short-circuited for any falsy value, so `null` and `NaN` bypassed validation and were stored as the level. Changed to `options.level !== undefined` so these values are properly rejected.

- **S6 — Browser Chromium version comparison** (`browser.js`): `brand.version > 93` relied on implicit string-to-number coercion. The UA spec returns `version` as a string; added explicit `Number(brand.version)` to make the intent clear and safe.

### Performance / correctness fixes

- **P1 — Stateful regex bug in `rainbow.js`** (`examples/rainbow.js`): The global-flagged regex `ignoreChars` was used with `.test()` inside a loop. Because `RegExp.prototype.test()` advances `lastIndex` after each match, consecutive non-printable characters (e.g. double-space, `\t\n`) were alternately misclassified — every other non-printable was incorrectly treated as printable. Replaced with a direct code-point comparison (`character < '!' || character > '~'`), which is also faster.

- **P4 — String concatenation in `stringEncaseCRLFWithFirstIndex`** (`utilities.js`): The loop used `returnValue +=` which allocates a new string on every iteration. Switched to collecting parts in an array and joining once at the end, reducing intermediate allocations for strings with many newlines.

- **P6 — Tagged template literals with interpolations** (`index.js`): `` chalk.red`hello ${name}` `` previously produced incorrect output (`"hello , World"`) because the builder treated the template strings array and interpolated values as flat `join(' ')` arguments. The builder now detects a tagged template call via the `.raw` property on the first argument and routes through `String.raw()` for correct interleaving.

## Test plan

- [x] All 35 pre-existing tests pass (`npm test`)
- [x] New test: `new Chalk({level: null})` and `new Chalk({level: NaN})` throw (S5)
- [x] New test: `hex(0xFF0000)`, `hex(0x0000FF)`, `hex(0x00FF00)` match their string equivalents including leading-zero case (S2)
- [x] New test: `` chalk.red`hello ${name}` `` and `` chalk.bold`count: ${42}` `` produce correctly styled output; plain array arguments unaffected (P6)
- [x] Lint clean (xo) — 0 errors, 6 pre-existing warnings (all in upstream TODO comments or pre-existing complexity)
- [x] Type checks pass (tsd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)