### PR TITLE
fix: respect FORCE_COLOR env var over auto-detection

### DIFF
--- a/source/vendor/supports-color/index.js
+++ b/source/vendor/supports-color/index.js
@@ -93,6 +93,12 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 
 	const min = forceColor || 0;
 
+	// If forceColor was explicitly set (via FORCE_COLOR env or --color flag),
+	// respect it and don't override with auto-detection
+	if (forceColor !== undefined) {
+		return min;
+	}
+
 	if (env.TERM === 'dumb') {
 		return min;
 	}


### PR DESCRIPTION
Fixes #624

## What
This fix ensures that when `FORCE_COLOR` environment variable is explicitly set, its value takes precedence over automatic color support detection from `COLORTERM`, `TERM`, and other environment variables.

## Why
Previously, setting `FORCE_COLOR=1` would be overridden by `COLORTERM=truecolor` (or other color-supporting terminal settings), resulting in level 3 being returned instead of the expected level 1.

## How
Added an early return check after calculating `min` that returns immediately if `forceColor` was explicitly set (not undefined), preventing subsequent auto-detection logic from overriding the user-specified value.

## Testing
- `FORCE_COLOR=0` → level 0 (no colors) ✅
- `FORCE_COLOR=1` → level 1 ✅
- `FORCE_COLOR=2` → level 2 ✅
- `FORCE_COLOR=3` → level 3 ✅
- `FORCE_COLOR=true` → level 1 ✅
- `FORCE_COLOR=false` → level 0 ✅
- All 32 existing tests pass ✅