### PR TITLE
Replace Codecov with Qlty for code coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test
-      - uses: codecov/codecov-action@v2
+      - uses: qltysh/qlty-action/coverage@v2
         if: matrix.node-version == 16
         with:
-          fail_ci_if_error: true
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info


### PR DESCRIPTION
## Summary
- Replace `codecov/codecov-action@v2` with `qltysh/qlty-action/coverage@v2` in CI workflow
- Upload `coverage/lcov.info` (generated by c8) from the Node 16 matrix run
- Use token-based authentication (public repo)

## Manual steps required
1. Add the `QLTY_COVERAGE_TOKEN` repository secret in GitHub Settings → Secrets and variables → Actions
   - Get the token from Qlty Cloud: Workspace Settings → Code Coverage

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Verify coverage data appears in Qlty Cloud after adding the secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)