### PR TITLE
fix: validate non-numeric level options

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -22,7 +22,7 @@ const levelMapping = [
 const styles = Object.create(null);
 
 const applyOptions = (object, options = {}) => {
-	if (options.level && !(Number.isInteger(options.level) && options.level >= 0 && options.level <= 3)) {
+	if (options.level !== undefined && !(Number.isInteger(options.level) && options.level >= 0 && options.level <= 3)) {
 		throw new Error('The `level` option should be an integer from 0 to 3');
 	}
 

--- a/test/instance.js
+++ b/test/instance.js
@@ -20,5 +20,13 @@ test('the `level` option should be a number from 0 to 3', t => {
 	t.throws(() => {
 		new Chalk({level: -1});
 	}, {message: /should be an integer from 0 to 3/});
+
+	t.throws(() => {
+		new Chalk({level: null});
+	}, {message: /should be an integer from 0 to 3/});
+
+	t.throws(() => {
+		new Chalk({level: Number.NaN});
+	}, {message: /should be an integer from 0 to 3/});
 	/* eslint-enable no-new */
 });


### PR DESCRIPTION

**Repo:** chalk/chalk (⭐ 22000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +9/-1

## What
This change tightens `Chalk` option validation so `level` is validated whenever it is explicitly provided, not only when it is truthy. It updates the runtime check in `source/index.js` and adds regression coverage in `test/instance.js` for `null` and `NaN` inputs, which previously slipped through and created invalid `Chalk` instances.

## Why
`level` is documented as an integer from 0 to 3, but the existing guard accepted some invalid falsy values such as `null` and `NaN`. That made the runtime behavior inconsistent and allowed callers outside TypeScript to construct malformed instances. Rejecting all explicitly provided invalid values makes the API behavior match its contract and prevents harder-to-debug downstream issues.

## Testing
Verified locally with a targeted Node.js runtime check that `new Chalk({level: null})` and `new Chalk({level: Number.NaN})` now throw the documented error, while valid values like `0` and `1` still work. I did not run the repo's AVA test suite because `node_modules` is not installed in this workspace.

## Risk
Low / The change only narrows input validation for already-invalid runtime values and adds focused regression tests.
